### PR TITLE
MODPATBLK-10 update RMB and vertx version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>29.4.0</raml-module-builder.version>
-    <vertx.version>3.8.4</vertx.version>
+    <raml-module-builder.version>30.0.0</raml-module-builder.version>
+    <vertx.version>3.9.0</vertx.version>
     <junit.version>4.12</junit.version>
     <rest-assured.version>3.2.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/src/main/java/org/folio/patronblocks/repository/UserSummaryRepositoryImpl.java
+++ b/src/main/java/org/folio/patronblocks/repository/UserSummaryRepositoryImpl.java
@@ -14,7 +14,8 @@ import org.folio.rest.persist.interfaces.Results;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.ext.sql.UpdateResult;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 
 public class UserSummaryRepositoryImpl implements UserSummaryRepository {
 
@@ -56,16 +57,16 @@ public class UserSummaryRepositoryImpl implements UserSummaryRepository {
 
   @Override
   public Future<Boolean> updateUserSummary(UserSummary userSummary) {
-    Promise<UpdateResult> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     pgClient.update(USER_SUMMARY_TABLE, userSummary, userSummary.getId(), promise);
-    return promise.future().map(updateResult -> updateResult.getUpdated() == 1);
+    return promise.future().map(updateResult -> updateResult.rowCount() == 1);
   }
 
   @Override
   public Future<Boolean> deleteUserSummary(String id) {
-    Promise<UpdateResult> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     pgClient.delete(USER_SUMMARY_TABLE, id, promise);
-    return promise.future().map(updateResult -> updateResult.getUpdated() == 1);
+    return promise.future().map(updateResult -> updateResult.rowCount() == 1);
   }
 
   /**

--- a/src/test/java/org/folio/patronblocks/repository/UserSummaryRepositoryImplTest.java
+++ b/src/test/java/org/folio/patronblocks/repository/UserSummaryRepositoryImplTest.java
@@ -120,8 +120,12 @@ public class UserSummaryRepositoryImplTest extends APITests {
       .atMost(1, TimeUnit.SECONDS)
       .until(userSummaryRepository.getUserSummaries(null, 0, 100)::result, hasSize(3));
 
-    userSummaryRepository.deleteUserSummary(userSummaryId1);
-    userSummaryRepository.deleteUserSummary(userSummaryId3);
+    Future<Boolean> deleteUserSummary1 = userSummaryRepository.deleteUserSummary(userSummaryId1);
+    Future<Boolean> deleteUserSummary2 = userSummaryRepository.deleteUserSummary(userSummaryId3);
+
+    Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(() -> deleteUserSummary1.isComplete() && deleteUserSummary2.isComplete());
 
     Future<List<UserSummary>> userSummaryRemaining =
       userSummaryRepository.getUserSummaries(null, 0, 100);


### PR DESCRIPTION
## Approach
- Update to RMB v30
- Update vertx to 3.9.0
- Do all related changes according to RMB upgrading notes

Resolves: [MODPATBLK-10](https://issues.folio.org/browse/MODPATBLK-10)