### PR TITLE
MODPATBLK-17 Register module as a publisher

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -89,6 +89,7 @@
           ],
           "pathPattern": "/_/tenant",
           "modulePermissions": [
+            "pubsub.publishers.delete",
             "pubsub.subscribers.delete"
           ]
         }

--- a/src/main/resources/MessagingDescriptor.json
+++ b/src/main/resources/MessagingDescriptor.json
@@ -1,5 +1,35 @@
 {
   "publications": [
+    {
+      "eventType": "ITEM_CHECKED_OUT",
+      "description": "Item was checked out",
+      "eventTTL": 1,
+      "signed": false
+    },
+    {
+      "eventType": "ITEM_CHECKED_IN",
+      "description": "Item was checked in",
+      "eventTTL": 1,
+      "signed": false
+    },
+    {
+      "eventType": "ITEM_DECLARED_LOST",
+      "description": "Item has been declared lost",
+      "eventTTL": 1,
+      "signed": false
+    },
+    {
+      "eventType": "LOAN_DUE_DATE_CHANGED",
+      "description": "Due date for a loan has been changed",
+      "eventTTL": 1,
+      "signed": false
+    },
+    {
+      "eventType": "FEE_FINE_BALANCE_CHANGED",
+      "description": "Patron fee/fine balance was changed",
+      "eventTTL": 1,
+      "signed": false
+    }
   ],
   "subscriptions": [
     {

--- a/src/test/java/org/folio/rest/impl/TenantRefAPITest.java
+++ b/src/test/java/org/folio/rest/impl/TenantRefAPITest.java
@@ -29,7 +29,8 @@ public class TenantRefAPITest extends TestBase {
         context.assertEquals(500, response.statusCode());
         response.bodyHandler(body -> {
           context.assertTrue(body.toString().contains(
-            "Module's publishers were not registered in PubSub"));
+            "EventDescriptor was not registered for eventType"));
+
           async.complete();
         });
       });
@@ -43,6 +44,9 @@ public class TenantRefAPITest extends TestBase {
     Async async = context.async();
 
     wireMock.stubFor(delete(urlPathMatching("/pubsub/event-types/.+/subscribers"))
+      .willReturn(aResponse().withStatus(204)));
+
+    wireMock.stubFor(delete(urlPathMatching("/pubsub/event-types/.+/publishers"))
       .willReturn(aResponse().withStatus(204)));
 
     try {
@@ -73,7 +77,35 @@ public class TenantRefAPITest extends TestBase {
       tenantClient.deleteTenant(response -> {
         context.assertEquals(500, response.statusCode());
         response.bodyHandler(body -> context.assertTrue(body.toString()
-          .startsWith("deleteTenant execution failed: Failed to unsubscribe from events")));
+          .startsWith("deleteTenant execution failed: Failed to unregister. Event types:")));
+        async.complete();
+      });
+    } catch (Exception e) {
+      context.fail(e);
+    }
+  }
+
+  @Test
+  public void deleteTenantShouldFailWhenFailedToUnregisterPublishersFromPubSub(
+    TestContext context) {
+
+    Async async = context.async();
+
+    wireMock.stubFor(delete(urlPathEqualTo("/pubsub/event-types/ITEM_CHECKED_IN/publishers"))
+      .atPriority(1)
+      .willReturn(aResponse().withStatus(500)));
+    wireMock.stubFor(delete(urlPathEqualTo("/pubsub/event-types/ITEM_CHECKED_OUT/publishers"))
+      .atPriority(1)
+      .willReturn(aResponse().withStatus(400)));
+    wireMock.stubFor(delete(urlPathMatching("/pubsub/event-types/\\w+/publishers"))
+      .atPriority(10)
+      .willReturn(aResponse().withStatus(204)));
+
+    try {
+      tenantClient.deleteTenant(response -> {
+        context.assertEquals(500, response.statusCode());
+        response.bodyHandler(body -> context.assertTrue(body.toString()
+          .startsWith("deleteTenant execution failed: Failed to unregister. Event types:")));
         async.complete();
       });
     } catch (Exception e) {


### PR DESCRIPTION
Resolves [MODPATBLK-16](https://issues.folio.org/browse/MODPATBLK-16).

Implements a workaround for [MODPUBSUB-90](https://issues.folio.org/browse/MODPUBSUB-90) - register as a publisher of all of the events we want to subscribe to avoid "module registering order" issue.