### PR TITLE
MODPATBLK-20 Block when limit is reached

### DIFF
--- a/src/main/java/org/folio/domain/Condition.java
+++ b/src/main/java/org/folio/domain/Condition.java
@@ -15,25 +15,26 @@ import org.joda.time.LocalDate;
 
 public enum Condition {
   // IDs come from resources\templates\db_scripts\populate-patron-block-conditions.sql
+
   MAX_NUMBER_OF_ITEMS_CHARGED_OUT("3d7c52dc-c732-4223-8bf8-e5917801386f",
-    (summary, limit) -> summary.getOpenLoans().size() > limit.getValue()
+    (summary, limit) -> summary.getOpenLoans().size() >= limit.getValue()
   ),
 
   MAX_NUMBER_OF_LOST_ITEMS("72b67965-5b73-4840-bc0b-be8f3f6e047e",
-    (summary, limit) -> summary.getNumberOfLostItems() > limit.getValue()
+    (summary, limit) -> summary.getNumberOfLostItems() >= limit.getValue()
   ),
 
   MAX_NUMBER_OF_OVERDUE_ITEMS("584fbd4f-6a34-4730-a6ca-73a6a6a9d845",
     (summary, limit) -> summary.getOpenLoans().stream()
       .filter(Condition::isLoanOverdue)
-      .count() > limit.getValue()
+      .count() >= limit.getValue()
   ),
 
   MAX_NUMBER_OF_OVERDUE_RECALLS("e5b45031-a202-4abb-917b-e1df9346fe2c",
     (summary, limit) -> summary.getOpenLoans().stream()
       .filter(Condition::isLoanOverdue)
       .filter(OpenLoan::getRecall)
-      .count() > limit.getValue()
+      .count() >= limit.getValue()
   ),
 
   RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS("08530ac4-07f2-48e6-9dda-a97bc2bf7053",
@@ -41,12 +42,12 @@ public enum Condition {
       .filter(Condition::isLoanOverdue)
       .filter(OpenLoan::getRecall)
       .map(Condition::getLoanOverdueDays)
-      .anyMatch(days -> days > limit.getValue())
+      .anyMatch(days -> days >= limit.getValue())
   ),
 
   MAX_OUTSTANDING_FEE_FINE_BALANCE("cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a",
     (summary, limit) -> summary.getOutstandingFeeFineBalance()
-      .compareTo(BigDecimal.valueOf(limit.getValue())) > 0
+      .compareTo(BigDecimal.valueOf(limit.getValue())) >= 0
   );
 
   private final String id;
@@ -91,6 +92,4 @@ public enum Condition {
       ? Days.daysBetween(new LocalDate(loan.getDueDate()), LocalDate.now(DateTimeZone.UTC)).getDays()
       : 0;
   }
-
-
 }

--- a/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
@@ -226,7 +226,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     OpenLoan overdueLoan = new OpenLoan()
       .withLoanId(randomId())
       .withRecall(false)
-      .withDueDate(new Date());
+      .withDueDate(now().minusHours(1).toDate());
 
     List<OpenLoan> overdueLoans = fillListOfSize(overdueLoan, limitValue + openLoansSizeDelta);
     createSummary(USER_ID, BigDecimal.ZERO, 0, new ArrayList<>(), overdueLoans);
@@ -280,7 +280,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     OpenLoan overdueLoan = new OpenLoan()
       .withLoanId(randomId())
       .withRecall(true)
-      .withDueDate(new Date());
+      .withDueDate(now().minusHours(1).toDate());
 
     List<OpenLoan> loans = fillListOfSize(overdueLoan, limitValue + openLoansSizeDelta);
     createSummary(USER_ID, BigDecimal.ZERO, 0, new ArrayList<>(), loans);


### PR DESCRIPTION
Resolves [MODPATBLK-20](https://issues.folio.org/browse/MODPATBLK-20).

All 6 blocks were only applied when the limit is exceeded. Instead, they should be also applied when the value is equal to the limit - otherwise the patron would be able to perform an extra action that should have been blocked.