### PR TITLE
MODPATBLK-30 Allow additional fields

### DIFF
--- a/ramls/user.json
+++ b/ramls/user.json
@@ -123,7 +123,7 @@
                 "type": "boolean"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "preferredContactTypeId": {
@@ -131,7 +131,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "lastName"
       ]
@@ -170,5 +170,5 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/src/test/java/org/folio/rest/client/UsersClientTest.java
+++ b/src/test/java/org/folio/rest/client/UsersClientTest.java
@@ -89,6 +89,24 @@ public class UsersClientTest extends TestBase {
       });
   }
 
+  @Test
+  public void additionalFieldShouldBeAllowed(TestContext context) {
+    Async async = context.async();
+
+    mockUsersResponse(200, new JsonObject()
+      .put("id", USER_ID)
+      .put("patronGroup", PATRON_GROUP_ID)
+      .put("additionalNonExistingField", "value")
+      .encodePrettily());
+
+    usersClient.findPatronGroupIdForUser(USER_ID)
+      .onFailure(context::fail)
+      .onSuccess(groupId -> {
+        context.assertEquals(PATRON_GROUP_ID, groupId);
+        async.complete();
+      });
+  }
+
   private void mockUsersResponse(int responseStatus, String responseBody) {
     wireMock.stubFor(get(urlPathMatching("/users/.+"))
       .willReturn(aResponse()


### PR DESCRIPTION
Resolves  [MODPATBLK-30](https://issues.folio.org/browse/MODPATBLK-30).

Allows `user` JSON schema to have additional fields.