### PR TITLE
MODPATBLK-35 Add GET UserSummary endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,6 +32,21 @@
       ]
     },
     {
+      "id":"user-summary",
+      "version":"0.1",
+      "handlers":[
+        {
+          "methods":[
+            "GET"
+          ],
+          "pathPattern":"/user-summary/{userId}",
+          "permissionsRequired": [
+            "user-summary.item.get"
+          ]
+        }
+      ]
+    },
+    {
       "id":"patron-blocks-event-handlers",
       "version":"1.0",
       "handlers":[

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -225,7 +225,7 @@
     },
     {
       "permissionName": "user-summary.item.get",
-      "displayName": "User summaries - get UserSummary object",
+      "displayName": "User summary - get UserSummary object",
       "description": "Get UserSummary object by user ID"
     }
   ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -222,6 +222,11 @@
       "permissionName": "automated-patron-blocks.collection.get",
       "displayName": "Patron blocks - get blocks for patron",
       "description": "Get automated patron blocks by user ID"
+    },
+    {
+      "permissionName": "user-summary.item.get",
+      "displayName": "User summaries - get UserSummary object",
+      "description": "Get UserSummary object by user ID"
     }
   ],
   "launchDescriptor": {

--- a/ramls/examples/user-summary.sample
+++ b/ramls/examples/user-summary.sample
@@ -1,0 +1,20 @@
+{
+  "id": "4879f476-2b5c-4b8d-9a1b-48d200e61517",
+  "userId": "16b5c87a-5fd6-41d5-b154-2e408f69a8ee",
+  "openLoans": [
+    {
+      "loanId": "c929faa8-f34b-4086-a193-45a25cbafa95",
+      "dueDate": "2020-01-01T23:23:23.000Z",
+      "recall": false,
+      "itemLost": false
+    }
+  ],
+  "openFeesFines": [
+    {
+      "feeFineId": "83eded7c-d480-4f36-bfca-6ccfaf5b013b",
+      "balance": 0,
+      "loanId": "f941762e-abad-4627-84e9-1a83de4cdc90",
+      "feeFineTypeId": "48aa663a-2ba4-4917-a193-ebe0c5e7caf5"
+    }
+  ]
+}

--- a/ramls/user-summary.raml
+++ b/ramls/user-summary.raml
@@ -1,0 +1,39 @@
+#%RAML 1.0
+title: Automated patron blocks
+version: v0.1
+baseUri: http://github.com/org/folio/mod-patron-blocks
+
+documentation:
+  - title: Diagnostic API for retreiving internal UserSummary objects
+    content: <b>User summary API</b>
+
+types:
+  errors: !include raml-util/schemas/errors.schema
+  userSummary: !include userSummary.json
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+
+/user-summary/{userId}:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            schema: userSummary
+            example: !include examples/user-summary.sample
+      400:
+        description: "Invalid user ID in request"
+        body:
+          text/plain:
+            example: "Invalid user ID: \"2a424823-588a-45ee-9441-a6384b6614b2-invalid\""
+      404:
+        description: "UserSummary not found"
+        body:
+          text/plain:
+            example: "UserSummary for user ID 2a424823-588a-45ee-9441-a6384b6614b1 not found"
+      500:
+        description: "Internal server error, e.g. due to misconfiguration"
+        body:
+          text/plain:
+            example: "Internal server error"

--- a/ramls/userSummary.json
+++ b/ramls/userSummary.json
@@ -97,8 +97,6 @@
   "required": [
     "id",
     "userId",
-    "outstandingFeeFineBalance",
-    "numberOfLostItems",
     "openLoans",
     "openFeesFines"
   ]

--- a/src/main/java/org/folio/domain/Condition.java
+++ b/src/main/java/org/folio/domain/Condition.java
@@ -10,9 +10,6 @@ import org.folio.rest.jaxrs.model.OpenFeeFine;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.PatronBlockLimit;
 import org.folio.rest.jaxrs.model.UserSummary;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Days;
-import org.joda.time.LocalDate;
 
 public enum Condition {
   // IDs come from resources\templates\db_scripts\populate-patron-block-conditions.sql

--- a/src/main/java/org/folio/domain/Condition.java
+++ b/src/main/java/org/folio/domain/Condition.java
@@ -94,7 +94,8 @@ public enum Condition {
 
   private static int getLoanOverdueDays(OpenLoan loan) {
     return isLoanOverdue(loan)
-      ? Days.daysBetween(new LocalDate(loan.getDueDate()), LocalDate.now(DateTimeZone.UTC)).getDays()
+      ? (int) Math.round(((double) (new Date().getTime() - loan.getDueDate().getTime()))
+      / 1000.0 / 60.0 / 60.0 / 24.0)
       : 0;
   }
 

--- a/src/main/java/org/folio/exception/EntityNotFoundInDbException.java
+++ b/src/main/java/org/folio/exception/EntityNotFoundInDbException.java
@@ -1,0 +1,7 @@
+package org.folio.exception;
+
+public class EntityNotFoundInDbException extends RuntimeException {
+  public EntityNotFoundInDbException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/repository/UserSummaryRepository.java
+++ b/src/main/java/org/folio/repository/UserSummaryRepository.java
@@ -1,5 +1,7 @@
 package org.folio.repository;
 
+import static io.vertx.core.Future.succeededFuture;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -41,7 +43,13 @@ public class UserSummaryRepository extends BaseRepository<UserSummary> {
         .setJSONB(true));
 
     return this.get(criterion)
-      .map(results -> results.stream().findFirst());
+      .compose(results -> {
+        if (results.isEmpty()) {
+          return succeededFuture(Optional.empty());
+        }
+
+        return succeededFuture(Optional.ofNullable(results.get(0)));
+      });
   }
 
   public Future<UserSummary> findByUserIdOrBuildNew(String userId) {

--- a/src/main/java/org/folio/rest/impl/UserSummaryAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserSummaryAPI.java
@@ -1,0 +1,46 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.format;
+import static org.folio.util.UuidUtil.isUuid;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.exception.EntityNotFoundInDbException;
+import org.folio.rest.jaxrs.resource.UserSummaryUserId;
+import org.folio.service.UserSummaryService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class UserSummaryAPI implements UserSummaryUserId {
+  @Override
+  public void getUserSummaryByUserId(String userId, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    if (!isUuid(userId)) {
+      asyncResultHandler.handle(succeededFuture(UserSummaryUserId.GetUserSummaryByUserIdResponse
+        .respond400WithTextPlain(format("Invalid user ID: \"%s\"", userId))));
+      return;
+    }
+
+    new UserSummaryService(okapiHeaders, vertxContext.owner()).getByUserId(userId)
+      .onSuccess(userSummary -> asyncResultHandler.handle(succeededFuture(
+        UserSummaryUserId.GetUserSummaryByUserIdResponse.respond200WithApplicationJson(userSummary))))
+      .onFailure(failure -> {
+        if (failure instanceof EntityNotFoundInDbException) {
+          asyncResultHandler.handle(succeededFuture(
+            UserSummaryUserId.GetUserSummaryByUserIdResponse.respond404WithTextPlain(
+              failure.getLocalizedMessage())));
+        }
+        else {
+          asyncResultHandler.handle(succeededFuture(
+            UserSummaryUserId.GetUserSummaryByUserIdResponse.respond500WithTextPlain(
+              failure.getLocalizedMessage())));
+        }
+      });
+  }
+}

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -1,0 +1,31 @@
+package org.folio.service;
+
+import static java.lang.String.format;
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+
+import java.util.Map;
+
+import org.folio.exception.EntityNotFoundInDbException;
+import org.folio.repository.UserSummaryRepository;
+import org.folio.rest.jaxrs.model.UserSummary;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.TenantTool;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+public class UserSummaryService {
+  private final UserSummaryRepository userSummaryRepository;
+
+  public UserSummaryService(Map<String, String> okapiHeaders, Vertx vertx) {
+    String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(TENANT));
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    userSummaryRepository = new UserSummaryRepository(postgresClient);
+  }
+
+  public Future<UserSummary> getByUserId(String userId) {
+    return userSummaryRepository.getByUserId(userId)
+      .map(optionalUserSummary -> optionalUserSummary.orElseThrow(() ->
+        new EntityNotFoundInDbException(format("User summary for user ID %s not found", userId))));
+  }
+}

--- a/src/test/java/org/folio/rest/TestBase.java
+++ b/src/test/java/org/folio/rest/TestBase.java
@@ -10,8 +10,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static java.lang.String.format;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -174,5 +176,13 @@ public class TestBase {
 
   protected static String toJson(Object event) {
     return JsonObject.mapFrom(event).encodePrettily();
+  }
+
+  protected <T> List<T> fillListOfSize(T object, int listSize) {
+    List<T> list = new ArrayList<>();
+    for (int i = 0; i < listSize; i++) {
+      list.add(object);
+    }
+    return list;
   }
 }

--- a/src/test/java/org/folio/rest/impl/UserSummaryAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UserSummaryAPITest.java
@@ -1,0 +1,79 @@
+package org.folio.rest.impl;
+
+import static java.lang.String.format;
+import static org.folio.repository.UserSummaryRepository.USER_SUMMARY_TABLE_NAME;
+import static org.folio.rest.utils.EntityBuilder.buildUserSummary;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.folio.repository.UserSummaryRepository;
+import org.folio.rest.TestBase;
+import org.folio.rest.jaxrs.model.OpenFeeFine;
+import org.folio.rest.jaxrs.model.OpenLoan;
+import org.folio.rest.jaxrs.model.UserSummary;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class UserSummaryAPITest extends TestBase {
+  private final UserSummaryRepository userSummaryRepository =
+    new UserSummaryRepository(postgresClient);
+
+  @Before
+  public void beforeEach() {
+    super.resetMocks();
+    deleteAllFromTable(USER_SUMMARY_TABLE_NAME);
+  }
+
+  @Test
+  public void shouldReturn400WhenCalledWithInvalidUserId() {
+    sendRequest("invalid")
+      .then()
+      .statusCode(400)
+      .contentType(ContentType.TEXT)
+      .body(equalTo("Invalid user ID: \"invalid\""));
+  }
+
+  @Test
+  public void shouldReturn404WhenUserSummaryDoesNotExist() {
+    String userId = randomId();
+
+    sendRequest(userId)
+      .then()
+      .statusCode(404)
+      .contentType(ContentType.TEXT)
+      .body(equalTo(format("User summary for user ID %s not found", userId)));
+  }
+
+  @Test
+  public void shouldReturn200WhenUserSummaryExistsAndIsValid() {
+    String userId = randomId();
+
+    createSummary(userId, new ArrayList<>(), new ArrayList<>());
+
+    UserSummary userSummary = waitFor(userSummaryRepository.getByUserId(userId)).get();
+
+    sendRequest(userId)
+      .then()
+      .statusCode(200)
+      .contentType(ContentType.JSON)
+      .body(equalTo(toJson(userSummary)));
+  }
+
+  private Response sendRequest(String userId) {
+    return okapiClient.get("user-summary/" + userId);
+  }
+
+  private String createSummary(String userId, List<OpenFeeFine> feesFines,
+    List<OpenLoan> openLoans) {
+
+    return waitFor(userSummaryRepository.save(buildUserSummary(userId, feesFines, openLoans)));
+  }
+}

--- a/src/test/java/org/folio/rest/utils/EntityBuilder.java
+++ b/src/test/java/org/folio/rest/utils/EntityBuilder.java
@@ -10,7 +10,7 @@ import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 
 public class EntityBuilder {
-  protected static String randomId() {
+  private static String randomId() {
     return UUID.randomUUID().toString();
   }
 

--- a/src/test/java/org/folio/rest/utils/EntityBuilder.java
+++ b/src/test/java/org/folio/rest/utils/EntityBuilder.java
@@ -1,0 +1,48 @@
+package org.folio.rest.utils;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.rest.jaxrs.model.OpenFeeFine;
+import org.folio.rest.jaxrs.model.OpenLoan;
+import org.folio.rest.jaxrs.model.UserSummary;
+
+public class EntityBuilder {
+  protected static String randomId() {
+    return UUID.randomUUID().toString();
+  }
+
+  public static OpenLoan buildLoan(boolean recall, boolean itemLost, Date dueDate) {
+    return buildLoan(randomId(), recall, itemLost, dueDate);
+  }
+
+  public static OpenLoan buildLoan(String loanId, boolean recall, boolean itemLost, Date dueDate) {
+    return new OpenLoan()
+      .withLoanId(loanId)
+      .withDueDate(dueDate)
+      .withRecall(recall)
+      .withItemLost(itemLost);
+  }
+
+  public static OpenFeeFine buildFeeFine(String loanId, String feeFineId, String feeFineTypeId,
+    BigDecimal balance) {
+
+    return new OpenFeeFine()
+      .withLoanId(loanId)
+      .withFeeFineId(feeFineId)
+      .withFeeFineTypeId(feeFineTypeId)
+      .withBalance(balance);
+  }
+
+  public static UserSummary buildUserSummary(String userId, List<OpenFeeFine> feesFines,
+    List<OpenLoan> openLoans) {
+
+    return new UserSummary()
+      .withId(randomId())
+      .withUserId(userId)
+      .withOpenFeesFines(feesFines)
+      .withOpenLoans(openLoans);
+  }
+}


### PR DESCRIPTION
Recent tickets, such as [MODPATBLK-35](https://issues.folio.org/browse/MODPATBLK-35), [MODPATBLK-26](https://issues.folio.org/browse/MODPATBLK-26), require this diagnostic endpoint for developers to be able to fetch the underlying UserSummary object and quickly troubleshoot issues with automated patron blocks.