### PR TITLE
MODPATBLK-34 Limits for 3 implemented automated patron blocks not working properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
       <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.12</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/folio/domain/ActionBlocks.java
+++ b/src/main/java/org/folio/domain/ActionBlocks.java
@@ -28,7 +28,7 @@ public class ActionBlocks {
 
   public static ActionBlocks byLimit(UserSummary userSummary, PatronBlockLimit limit) {
     if (userSummary == null || limit == null || limit.getValue() == null
-      || limit.getConditionId() == null || Condition.getById(limit.getConditionId()) == null) {
+      || limit.getConditionId() == null) {
 
       log.error("Failed to determine blocks: one of the parameters is null");
       return empty();

--- a/src/main/java/org/folio/domain/ActionBlocks.java
+++ b/src/main/java/org/folio/domain/ActionBlocks.java
@@ -27,18 +27,20 @@ public class ActionBlocks {
   private final boolean blockRenewals;
   private final boolean blockRequests;
 
-  public static ActionBlocks determineBlocks(UserSummary userSummary, PatronBlockLimit limit) {
+  public static ActionBlocks byLimit(UserSummary userSummary, PatronBlockLimit limit) {
 
     if (!ObjectUtils.allNotNull(userSummary, userSummary.getOpenLoans(), limit,
       limit.getConditionId(), Condition.getById(limit.getConditionId()), limit.getValue())) {
 
       log.error("Failed to determine blocks: one of the parameters is null");
-      return none();
+      return empty();
     }
 
     Condition condition = Condition.getById(limit.getConditionId());
 
-    boolean blockBorrowing = false, blockRenewals = false, blockRequests = false;
+    boolean blockBorrowing = false;
+    boolean blockRenewals = false;
+    boolean blockRequests = false;
 
     double limitValue = limit.getValue();
 
@@ -99,7 +101,17 @@ public class ActionBlocks {
     return blockRequests;
   }
 
-  public static ActionBlocks none() {
+  public boolean isNotEmpty() {
+    return blockBorrowing || blockRenewals || blockRequests;
+  }
+
+  public static ActionBlocks and(ActionBlocks left, ActionBlocks right) {
+    return new ActionBlocks(left.blockBorrowing && right.blockBorrowing,
+      left.blockRenewals && right.blockRenewals,
+      left.blockRequests && right.blockRequests);
+  }
+
+  public static ActionBlocks empty() {
     return new ActionBlocks(false, false, false);
   }
 

--- a/src/main/java/org/folio/domain/ActionBlocks.java
+++ b/src/main/java/org/folio/domain/ActionBlocks.java
@@ -11,7 +11,6 @@ import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.folio.rest.jaxrs.model.OpenFeeFine;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.PatronBlockLimit;
@@ -28,9 +27,8 @@ public class ActionBlocks {
   private final boolean blockRequests;
 
   public static ActionBlocks byLimit(UserSummary userSummary, PatronBlockLimit limit) {
-
-    if (!ObjectUtils.allNotNull(userSummary, userSummary.getOpenLoans(), limit,
-      limit.getConditionId(), Condition.getById(limit.getConditionId()), limit.getValue())) {
+    if (userSummary == null || limit == null || limit.getValue() == null
+      || limit.getConditionId() == null || Condition.getById(limit.getConditionId()) == null) {
 
       log.error("Failed to determine blocks: one of the parameters is null");
       return empty();

--- a/src/main/java/org/folio/domain/ActionBlocks.java
+++ b/src/main/java/org/folio/domain/ActionBlocks.java
@@ -1,0 +1,117 @@
+package org.folio.domain;
+
+import static org.folio.domain.Condition.MAX_NUMBER_OF_ITEMS_CHARGED_OUT;
+import static org.folio.domain.Condition.MAX_NUMBER_OF_LOST_ITEMS;
+import static org.folio.domain.Condition.MAX_NUMBER_OF_OVERDUE_ITEMS;
+import static org.folio.domain.Condition.MAX_NUMBER_OF_OVERDUE_RECALLS;
+import static org.folio.domain.Condition.MAX_OUTSTANDING_FEE_FINE_BALANCE;
+import static org.folio.domain.Condition.RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS;
+
+import java.lang.invoke.MethodHandles;
+import java.math.BigDecimal;
+import java.util.Date;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.folio.rest.jaxrs.model.OpenFeeFine;
+import org.folio.rest.jaxrs.model.OpenLoan;
+import org.folio.rest.jaxrs.model.PatronBlockLimit;
+import org.folio.rest.jaxrs.model.UserSummary;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class ActionBlocks {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final boolean blockBorrowing;
+  private final boolean blockRenewals;
+  private final boolean blockRequests;
+
+  public static ActionBlocks determineBlocks(UserSummary userSummary, PatronBlockLimit limit) {
+
+    if (!ObjectUtils.allNotNull(userSummary, userSummary.getOpenLoans(), limit,
+      limit.getConditionId(), Condition.getById(limit.getConditionId()), limit.getValue())) {
+
+      log.error("Failed to determine blocks: one of the parameters is null");
+      return none();
+    }
+
+    Condition condition = Condition.getById(limit.getConditionId());
+
+    boolean blockBorrowing = false, blockRenewals = false, blockRequests = false;
+
+    double limitValue = limit.getValue();
+
+    if (condition == MAX_NUMBER_OF_ITEMS_CHARGED_OUT) {
+      int numberOfOpenLoans = userSummary.getOpenLoans().size();
+
+      blockBorrowing = numberOfOpenLoans >= limitValue;
+      blockRenewals = blockRequests = numberOfOpenLoans > limitValue;
+    }
+    else if (condition == MAX_NUMBER_OF_LOST_ITEMS) {
+      blockBorrowing = blockRenewals = blockRequests = userSummary.getOpenLoans().stream()
+        .filter(OpenLoan::getItemLost)
+        .count() > limitValue;
+    }
+    else if (condition == MAX_NUMBER_OF_OVERDUE_ITEMS) {
+      blockBorrowing = blockRenewals = blockRequests = userSummary.getOpenLoans().stream()
+        .filter(ActionBlocks::isLoanOverdue)
+        .count() > limitValue;
+    }
+    else if (condition == MAX_NUMBER_OF_OVERDUE_RECALLS) {
+      blockBorrowing = blockRenewals = blockRequests = userSummary.getOpenLoans().stream()
+        .filter(ActionBlocks::isLoanOverdue)
+        .filter(OpenLoan::getRecall)
+        .count() > limitValue;
+    }
+    else if (condition == RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS) {
+      blockBorrowing = blockRenewals = blockRequests = userSummary.getOpenLoans().stream()
+        .filter(ActionBlocks::isLoanOverdue)
+        .filter(OpenLoan::getRecall)
+        .map(ActionBlocks::getLoanOverdueDays)
+        .anyMatch(days -> days > limitValue);
+    }
+    else if (condition == MAX_OUTSTANDING_FEE_FINE_BALANCE) {
+      blockBorrowing = blockRenewals = blockRequests = userSummary.getOpenFeesFines().stream()
+        .map(OpenFeeFine::getBalance)
+        .reduce(BigDecimal.ZERO, BigDecimal::add)
+        .compareTo(BigDecimal.valueOf(limitValue)) > 0;
+    }
+
+    return new ActionBlocks(blockBorrowing, blockRenewals, blockRequests);
+  }
+
+  public ActionBlocks(boolean blockBorrowing, boolean blockRenewals, boolean blockRequests) {
+    this.blockBorrowing = blockBorrowing;
+    this.blockRenewals = blockRenewals;
+    this.blockRequests = blockRequests;
+  }
+
+  public boolean getBlockBorrowing() {
+    return blockBorrowing;
+  }
+
+  public boolean getBlockRenewals() {
+    return blockRenewals;
+  }
+
+  public boolean getBlockRequests() {
+    return blockRequests;
+  }
+
+  public static ActionBlocks none() {
+    return new ActionBlocks(false, false, false);
+  }
+
+  private static boolean isLoanOverdue(OpenLoan loan) {
+    Date dueDate = loan.getDueDate();
+    return dueDate != null && dueDate.before(new Date());
+  }
+
+  private static int getLoanOverdueDays(OpenLoan loan) {
+    return isLoanOverdue(loan)
+      ? (int) Math.round(((double) (new Date().getTime() - loan.getDueDate().getTime()))
+      / 1000.0 / 60.0 / 60.0 / 24.0)
+      : 0;
+  }
+}

--- a/src/main/java/org/folio/domain/Condition.java
+++ b/src/main/java/org/folio/domain/Condition.java
@@ -1,59 +1,19 @@
 package org.folio.domain;
 
-import java.math.BigDecimal;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiPredicate;
-
-import org.folio.rest.jaxrs.model.OpenFeeFine;
-import org.folio.rest.jaxrs.model.OpenLoan;
-import org.folio.rest.jaxrs.model.PatronBlockLimit;
-import org.folio.rest.jaxrs.model.UserSummary;
 
 public enum Condition {
   // IDs come from resources\templates\db_scripts\populate-patron-block-conditions.sql
 
-  MAX_NUMBER_OF_ITEMS_CHARGED_OUT("3d7c52dc-c732-4223-8bf8-e5917801386f",
-    (summary, limit) -> summary.getOpenLoans().size() >= limit.getValue()
-  ),
-
-  MAX_NUMBER_OF_LOST_ITEMS("72b67965-5b73-4840-bc0b-be8f3f6e047e",
-    (summary, limit) -> summary.getOpenLoans().stream()
-      .filter(OpenLoan::getItemLost)
-      .count() >= limit.getValue()
-  ),
-
-  MAX_NUMBER_OF_OVERDUE_ITEMS("584fbd4f-6a34-4730-a6ca-73a6a6a9d845",
-    (summary, limit) -> summary.getOpenLoans().stream()
-      .filter(Condition::isLoanOverdue)
-      .count() >= limit.getValue()
-  ),
-
-  MAX_NUMBER_OF_OVERDUE_RECALLS("e5b45031-a202-4abb-917b-e1df9346fe2c",
-    (summary, limit) -> summary.getOpenLoans().stream()
-      .filter(Condition::isLoanOverdue)
-      .filter(OpenLoan::getRecall)
-      .count() >= limit.getValue()
-  ),
-
-  RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS("08530ac4-07f2-48e6-9dda-a97bc2bf7053",
-    (summary, limit) -> summary.getOpenLoans().stream()
-      .filter(Condition::isLoanOverdue)
-      .filter(OpenLoan::getRecall)
-      .map(Condition::getLoanOverdueDays)
-      .anyMatch(days -> days >= limit.getValue())
-  ),
-
-  MAX_OUTSTANDING_FEE_FINE_BALANCE("cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a",
-    (summary, limit) -> summary.getOpenFeesFines().stream()
-      .map(OpenFeeFine::getBalance)
-      .reduce(BigDecimal.ZERO, BigDecimal::add)
-      .compareTo(BigDecimal.valueOf(limit.getValue())) >= 0
-  );
+  MAX_NUMBER_OF_ITEMS_CHARGED_OUT("3d7c52dc-c732-4223-8bf8-e5917801386f"),
+  MAX_NUMBER_OF_LOST_ITEMS("72b67965-5b73-4840-bc0b-be8f3f6e047e"),
+  MAX_NUMBER_OF_OVERDUE_ITEMS("584fbd4f-6a34-4730-a6ca-73a6a6a9d845"),
+  MAX_NUMBER_OF_OVERDUE_RECALLS("e5b45031-a202-4abb-917b-e1df9346fe2c"),
+  RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS("08530ac4-07f2-48e6-9dda-a97bc2bf7053"),
+  MAX_OUTSTANDING_FEE_FINE_BALANCE("cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a");
 
   private final String id;
-  private final BiPredicate<UserSummary, PatronBlockLimit> limitEvaluator;
   private static final Map<String, Condition> idIndex = new HashMap<>(Condition.values().length);
 
   static {
@@ -62,9 +22,8 @@ public enum Condition {
     }
   }
 
-  Condition(String id, BiPredicate<UserSummary, PatronBlockLimit> limitEvaluator) {
+  Condition(String id) {
     this.id = id;
-    this.limitEvaluator = limitEvaluator;
   }
 
   public String getId() {
@@ -74,26 +33,4 @@ public enum Condition {
   public static Condition getById(String id) {
     return idIndex.get(id);
   }
-
-  public boolean isLimitExceeded(UserSummary summary, PatronBlockLimit limit) {
-    return limitEvaluator.test(summary, limit);
-  }
-
-  public static boolean isConditionLimitExceeded(UserSummary summary, PatronBlockLimit limit) {
-    return idIndex.get(limit.getConditionId())
-      .limitEvaluator.test(summary, limit);
-  }
-
-  private static boolean isLoanOverdue(OpenLoan loan) {
-    Date dueDate = loan.getDueDate();
-    return dueDate != null && dueDate.before(new Date());
-  }
-
-  private static int getLoanOverdueDays(OpenLoan loan) {
-    return isLoanOverdue(loan)
-      ? (int) Math.round(((double) (new Date().getTime() - loan.getDueDate().getTime()))
-      / 1000.0 / 60.0 / 60.0 / 24.0)
-      : 0;
-  }
-
 }

--- a/src/main/java/org/folio/repository/UserSummaryRepository.java
+++ b/src/main/java/org/folio/repository/UserSummaryRepository.java
@@ -1,9 +1,9 @@
 package org.folio.repository;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.util.UuidHelper.randomId;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.Criteria.Criteria;
@@ -66,7 +66,7 @@ public class UserSummaryRepository extends BaseRepository<UserSummary> {
 
   private UserSummary buildEmptyUserSummary(String userId) {
     return new UserSummary()
-      .withId(UUID.randomUUID().toString())
+      .withId(randomId())
       .withUserId(userId);
   }
 

--- a/src/main/java/org/folio/util/UuidHelper.java
+++ b/src/main/java/org/folio/util/UuidHelper.java
@@ -1,5 +1,7 @@
 package org.folio.util;
 
+import java.util.UUID;
+
 import javax.validation.ValidationException;
 
 public class UuidHelper {
@@ -16,5 +18,9 @@ public class UuidHelper {
 
   public static void validateUUID(String uuid) {
     validateUUID(uuid, true);
+  }
+
+  public static String randomId() {
+    return UUID.randomUUID().toString();
   }
 }

--- a/src/test/java/org/folio/domain/ActionBlocksTest.java
+++ b/src/test/java/org/folio/domain/ActionBlocksTest.java
@@ -1,0 +1,47 @@
+package org.folio.domain;
+
+import static org.folio.util.UuidHelper.randomId;
+import static org.junit.Assert.assertFalse;
+
+import org.folio.rest.jaxrs.model.PatronBlockLimit;
+import org.folio.rest.jaxrs.model.UserSummary;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class ActionBlocksTest {
+
+  @Test
+  @Parameters
+  public void shouldReturnEmptyBlocks(UserSummary summary, PatronBlockLimit limit) {
+    ActionBlocks actionBlocks = ActionBlocks.byLimit(summary, limit);
+    assertAllBlocksAreFalse(actionBlocks);
+  }
+
+  public Object[] parametersForShouldReturnEmptyBlocks() {
+    final UserSummary userSummary = new UserSummary();
+    final PatronBlockLimit limit = new PatronBlockLimit();
+
+    return new Object[] {
+      new Object[] { null, null },
+      new Object[] { userSummary, null },
+      new Object[] { userSummary, limit },
+      new Object[] { userSummary, limit.withValue(1.23) },
+      new Object[] { userSummary, limit.withValue(1.23).withConditionId(randomId()) }
+    };
+  }
+
+  @Test
+  public void emptyReturnsEmptyBlocks() {
+    assertAllBlocksAreFalse(ActionBlocks.empty());
+  }
+
+  private static void assertAllBlocksAreFalse(ActionBlocks actionBlocks) {
+    assertFalse(actionBlocks.getBlockBorrowing());
+    assertFalse(actionBlocks.getBlockRenewals());
+    assertFalse(actionBlocks.getBlockRequests());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
@@ -476,7 +476,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     PatronBlockCondition updatedCondition = new PatronBlockCondition()
       .withId(condition.getId())
       .withBlockBorrowing(!originalCondition.getBlockBorrowing())
-      .withBlockRenewals(!originalCondition.getBlockRenewals())
+      .withBlockRenewals(originalCondition.getBlockRenewals())
       .withBlockRequests(!originalCondition.getBlockRequests())
       .withMessage(EMPTY);
 

--- a/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.folio.domain.Condition;
@@ -56,8 +57,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 public class AutomatedPatronBlocksAPITest extends TestBase {
   private static final String USER_ID = randomId();
   private static final String PATRON_GROUP_ID = randomId();
-  private static final boolean BLOCK_SHOULD_EXIST = true;
-  private static final boolean NO_BLOCKS_SHOULD_EXIST = false;
   private static final boolean SINGLE_LIMIT = true;
   private static final boolean ALL_LIMITS = false;
 
@@ -78,6 +77,10 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     LIMIT_VALUES.put(RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS, 60);
     LIMIT_VALUES.put(MAX_OUTSTANDING_FEE_FINE_BALANCE, 70);
   }
+
+  private boolean expectBlockBorrowing = false;
+  private boolean expectBlockRenewals = false;
+  private boolean expectBlockRequests = false;
 
   @Before
   public void beforeEach() {
@@ -110,240 +113,273 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
   }
 
   private void validateMaxNumberOfItemsChargedOutBlockResponse(int openLoansSizeDelta,
-    boolean singleLimit, boolean blockShouldExist) {
+    boolean singleLimit) {
 
     final Condition condition = MAX_NUMBER_OF_ITEMS_CHARGED_OUT;
+    updateCondition(condition, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
+
     final int limitValue = LIMIT_VALUES.get(condition);
 
     OpenLoan openLoan = buildLoan(false, false, now().plusHours(1).toDate());
     List<OpenLoan> openLoans = fillListOfSize(openLoan, limitValue + openLoansSizeDelta);
     createSummary(USER_ID, new ArrayList<>(), openLoans);
 
-    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit,
-      blockShouldExist);
+    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit);
 
     sendRequestAndCheckResult(expectedResponse);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfItemsChargedOutLimitIsNotReached() {
-    validateMaxNumberOfItemsChargedOutBlockResponse(-1, SINGLE_LIMIT, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxNumberOfItemsChargedOutBlockResponse(-1, SINGLE_LIMIT);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfItemsChargedOutLimitIsNotReachedAndAllLimitsExist() {
-    validateMaxNumberOfItemsChargedOutBlockResponse(-1, ALL_LIMITS, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxNumberOfItemsChargedOutBlockResponse(-1, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenMaxNumberOfItemsChargedOutLimitIsReached() {
-    validateMaxNumberOfItemsChargedOutBlockResponse(0, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectBlockBorrowing = true;
+    expectBlockRenewals = false;
+    expectBlockRequests = false;
+    validateMaxNumberOfItemsChargedOutBlockResponse(0, SINGLE_LIMIT);
   }
 
   @Test
   public void blockWhenMaxNumberOfItemsChargedOutLimitIsReachedAndAllLimitsExist() {
-    validateMaxNumberOfItemsChargedOutBlockResponse(0, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+    expectBlockBorrowing = true;
+    expectBlockRenewals = false;
+    expectBlockRequests = false;
+    validateMaxNumberOfItemsChargedOutBlockResponse(0, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenMaxNumberOfItemsChargedOutLimitIsExceeded() {
-    validateMaxNumberOfItemsChargedOutBlockResponse(1, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxNumberOfItemsChargedOutBlockResponse(1, SINGLE_LIMIT);
   }
 
   @Test
-  public void blockWhenMaxNumberOfItemsChargedOutLimitIsExceededAndAllLimitsExist() {
-    validateMaxNumberOfItemsChargedOutBlockResponse(1, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+  public void blockWhenMaxNumberOfItemsChargedOutLimitIsExceededAndAllLimitsExist() {expectAllBlocks();
+    validateMaxNumberOfItemsChargedOutBlockResponse(1, ALL_LIMITS);
   }
 
-  private void validateMaxNumberOfLostItemsBlockResponse(int lostItemsDelta, boolean singleLimit,
-    boolean blockShouldExist) {
-
+  private void validateMaxNumberOfLostItemsBlockResponse(int lostItemsDelta, boolean singleLimit) {
     final Condition condition = MAX_NUMBER_OF_LOST_ITEMS;
     int limitValue = LIMIT_VALUES.get(condition);
+
+    updateCondition(condition, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
 
     OpenLoan openLoan = buildLoan(false, true, now().plusHours(1).toDate());
     List<OpenLoan> openLoans = fillListOfSize(openLoan, limitValue + lostItemsDelta);
     createSummary(USER_ID, new ArrayList<>(), openLoans);
 
-    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit,
-      blockShouldExist);
+    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit);
 
     sendRequestAndCheckResult(expectedResponse);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfLostItemsLimitIsNotReached() {
-    validateMaxNumberOfLostItemsBlockResponse(-1, SINGLE_LIMIT, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxNumberOfLostItemsBlockResponse(-1, SINGLE_LIMIT);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfLostItemsLimitIsNotReachedAndAllLimitsExist() {
-    validateMaxNumberOfLostItemsBlockResponse(-1, ALL_LIMITS, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxNumberOfLostItemsBlockResponse(-1, ALL_LIMITS);
   }
 
   @Test
-  public void blockWhenMaxNumberOfLostItemsLimitIsReached() {
-    validateMaxNumberOfLostItemsBlockResponse(0, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxNumberOfLostItemsLimitIsReached() {
+    expectNoBlocks();
+    validateMaxNumberOfLostItemsBlockResponse(0, SINGLE_LIMIT);
   }
 
   @Test
-  public void blockWhenMaxNumberOfLostItemsLimitIsReachedAndAllLimitsExist() {
-    validateMaxNumberOfLostItemsBlockResponse(0, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxNumberOfLostItemsLimitIsReachedAndAllLimitsExist() {
+    expectNoBlocks();
+    validateMaxNumberOfLostItemsBlockResponse(0, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenMaxNumberOfLostItemsLimitIsExceeded() {
-    validateMaxNumberOfLostItemsBlockResponse(1, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxNumberOfLostItemsBlockResponse(1, SINGLE_LIMIT);
   }
 
   @Test
   public void blockWhenMaxNumberOfLostItemsLimitIsExceededAndAllLimitsExist() {
-    validateMaxNumberOfLostItemsBlockResponse(1, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxNumberOfLostItemsBlockResponse(1, ALL_LIMITS);
   }
 
-  private void validateMaxOverdueItemsBlockResponse(int openLoansSizeDelta, boolean singleLimit,
-    boolean blockShouldExist) {
-
+  private void validateMaxOverdueItemsBlockResponse(int openLoansSizeDelta, boolean singleLimit) {
     final Condition condition = MAX_NUMBER_OF_OVERDUE_ITEMS;
+    updateCondition(condition, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
+
     int limitValue = LIMIT_VALUES.get(condition);
 
     OpenLoan overdueLoan = buildLoan(false, false, now().minusHours(1).toDate());
     List<OpenLoan> overdueLoans = fillListOfSize(overdueLoan, limitValue + openLoansSizeDelta);
     createSummary(USER_ID, new ArrayList<>(), overdueLoans);
 
-    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit,
-      blockShouldExist);
+    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit);
 
     sendRequestAndCheckResult(expectedResponse);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfOverdueItemsLimitIsNotReached() {
-    validateMaxOverdueItemsBlockResponse(-1, SINGLE_LIMIT, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxOverdueItemsBlockResponse(-1, SINGLE_LIMIT);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfOverdueItemsLimitIsNotReachedAndAllLimitsExist() {
-    validateMaxOverdueItemsBlockResponse(-1, ALL_LIMITS, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxOverdueItemsBlockResponse(-1, ALL_LIMITS);
   }
 
   @Test
-  public void blockWhenMaxNumberOfOverdueItemsLimitIsReached() {
-    validateMaxOverdueItemsBlockResponse(0, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxNumberOfOverdueItemsLimitIsReached() {
+    expectNoBlocks();
+    validateMaxOverdueItemsBlockResponse(0, SINGLE_LIMIT);
   }
 
   @Test
-  public void blockWhenMaxNumberOfOverdueItemsLimitReachedAndAllLimitsExist() {
-    validateMaxOverdueItemsBlockResponse(0, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxNumberOfOverdueItemsLimitReachedAndAllLimitsExist() {
+    expectNoBlocks();
+    validateMaxOverdueItemsBlockResponse(0, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenMaxNumberOfOverdueItemsLimitIsExceeded() {
-    validateMaxOverdueItemsBlockResponse(1, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxOverdueItemsBlockResponse(1, SINGLE_LIMIT);
   }
 
   @Test
   public void blockWhenMaxNumberOfOverdueItemsLimitIsExceededAndAllLimitsExist() {
-    validateMaxOverdueItemsBlockResponse(1, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxOverdueItemsBlockResponse(1, ALL_LIMITS);
   }
 
-  private void validateMaxOverdueRecallsBlockResponse(int openLoansSizeDelta, boolean singleLimit,
-    boolean blockShouldExist) {
-
+  private void validateMaxOverdueRecallsBlockResponse(int openLoansSizeDelta, boolean singleLimit) {
     Condition condition = MAX_NUMBER_OF_OVERDUE_RECALLS;
+    updateCondition(condition, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
+
     int limitValue = LIMIT_VALUES.get(condition);
 
     OpenLoan overdueLoan = buildLoan(true, false, now().minusHours(1).toDate());
     List<OpenLoan> loans = fillListOfSize(overdueLoan, limitValue + openLoansSizeDelta);
     createSummary(USER_ID, new ArrayList<>(), loans);
 
-    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit,
-      blockShouldExist);
+    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit);
 
     sendRequestAndCheckResult(expectedResponse);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfOverdueRecallsLimitIsNotReached() {
-    validateMaxOverdueRecallsBlockResponse(-1, SINGLE_LIMIT, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxOverdueRecallsBlockResponse(-1, SINGLE_LIMIT);
   }
 
   @Test
   public void noBlockWhenMaxNumberOfOverdueRecallsLimitIsNotReachedAndAllLimitsExist() {
-    validateMaxOverdueRecallsBlockResponse(-1, ALL_LIMITS, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxOverdueRecallsBlockResponse(-1, ALL_LIMITS);
   }
 
   @Test
-  public void blockWhenMaxNumberOfOverdueRecallsLimitIsReached() {
-    validateMaxOverdueRecallsBlockResponse(0, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxNumberOfOverdueRecallsLimitIsReached() {
+    expectNoBlocks();
+    validateMaxOverdueRecallsBlockResponse(0, SINGLE_LIMIT);
   }
 
   @Test
-  public void blockWhenMaxNumberOfOverdueRecallsLimitIsReachedAndAllLimitsExist() {
-    validateMaxOverdueRecallsBlockResponse(0, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxNumberOfOverdueRecallsLimitIsReachedAndAllLimitsExist() {
+    expectNoBlocks();
+    validateMaxOverdueRecallsBlockResponse(0, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenMaxNumberOfOverdueRecallsLimitIsExceeded() {
-    validateMaxOverdueRecallsBlockResponse(1, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxOverdueRecallsBlockResponse(1, SINGLE_LIMIT);
   }
 
   @Test
   public void blockWhenMaxNumberOfOverdueRecallsLimitIsExceededAllLimitsExist() {
-    validateMaxOverdueRecallsBlockResponse(1, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxOverdueRecallsBlockResponse(1, ALL_LIMITS);
   }
 
   private void validateRecallOverdueByMaximumNumberOfDaysBlockResponse(int dueDateDelta,
-    boolean singleLimit, boolean blockShouldExist) {
+    boolean singleLimit) {
 
     final Condition condition = RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS;
+    updateCondition(condition, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
+
     int limitValue = LIMIT_VALUES.get(condition);
 
     DateTime dueDateBelowLimit = now().minusDays(limitValue + dueDateDelta);
     OpenLoan overdueLoan = buildLoan(true, false, dueDateBelowLimit.toDate());
     createSummary(USER_ID, new ArrayList<>(), singletonList(overdueLoan));
 
-    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit,
-      blockShouldExist);
+    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit);
 
     sendRequestAndCheckResult(expectedResponse);
   }
 
   @Test
   public void noBlockWhenRecallOverdueByMaximumNumberOfDaysLimitIsNotReached() {
-    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(-1, SINGLE_LIMIT,
-      NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(-1, SINGLE_LIMIT);
   }
 
   @Test
   public void noBlockWhenRecallOverdueByMaximumNumberOfDaysLimitIsNotReachedAndAllLimitsExist() {
-    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(-1, ALL_LIMITS, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(-1, ALL_LIMITS);
   }
 
   @Test
-  public void blockWhenRecallOverdueByMaximumNumberOfDaysLimitIsReached() {
-    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(0, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenRecallOverdueByMaximumNumberOfDaysLimitIsReached() {
+    expectNoBlocks();
+    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(0, SINGLE_LIMIT);
   }
 
   @Test
-  public void blockWhenRecallOverdueByMaximumNumberOfDaysLimitIsReachedAndAllLimitsExist() {
-    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(0, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenRecallOverdueByMaximumNumberOfDaysLimitIsReachedAndAllLimitsExist() {
+    expectNoBlocks();
+    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(0, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenRecallOverdueByMaximumNumberOfDaysLimitIsExceeded() {
-    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(1, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(1, SINGLE_LIMIT);
   }
 
   @Test
   public void blockWhenRecallOverdueByMaximumNumberOfDaysLimitIsExceededAllLimitsExist() {
-    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(1, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateRecallOverdueByMaximumNumberOfDaysBlockResponse(1, ALL_LIMITS);
   }
 
   private void validateMaxOutstandingFeeFineBalanceBlockResponse(int feeFineBalanceDelta,
-    boolean singleLimit, boolean blockShouldExist) {
+    boolean singleLimit) {
 
     final Condition condition = MAX_OUTSTANDING_FEE_FINE_BALANCE;
+    updateCondition(condition, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
+
     int limitValue = LIMIT_VALUES.get(condition);
     int numberOfFeesFines = 2;
 
@@ -354,44 +390,54 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     List<OpenFeeFine> openFeeFines = fillListOfSize(openFeeFine, numberOfFeesFines);
     createSummary(USER_ID, openFeeFines, new ArrayList<>());
 
-    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit,
-      blockShouldExist);
+    String expectedResponse = createLimitsAndBuildExpectedResponse(condition, singleLimit);
 
     sendRequestAndCheckResult(expectedResponse);
   }
 
   @Test
   public void noBlockWhenMaxOutstandingFeeFineBalanceLimitIsNotReached() {
-    validateMaxOutstandingFeeFineBalanceBlockResponse(-1, SINGLE_LIMIT, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxOutstandingFeeFineBalanceBlockResponse(-1, SINGLE_LIMIT);
   }
 
   @Test
   public void noBlockWhenMaxOutstandingFeeFineBalanceLimitIsNotReachedAndAllLimitsExist() {
-    validateMaxOutstandingFeeFineBalanceBlockResponse(-1, ALL_LIMITS, NO_BLOCKS_SHOULD_EXIST);
+    expectNoBlocks();
+    validateMaxOutstandingFeeFineBalanceBlockResponse(-1, ALL_LIMITS);
   }
 
   @Test
-  public void blockWhenMaxOutstandingFeeFineBalanceLimitIsReached() {
-    validateMaxOutstandingFeeFineBalanceBlockResponse(0, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxOutstandingFeeFineBalanceLimitIsReached() {
+    expectNoBlocks();
+    validateMaxOutstandingFeeFineBalanceBlockResponse(0, SINGLE_LIMIT);
   }
 
   @Test
-  public void blockWhenMaxOutstandingFeeFineBalanceLimitIsReachedAndAllLimitsExist() {
-    validateMaxOutstandingFeeFineBalanceBlockResponse(0, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+  public void noBlockWhenMaxOutstandingFeeFineBalanceLimitIsReachedAndAllLimitsExist() {
+    expectNoBlocks();
+    validateMaxOutstandingFeeFineBalanceBlockResponse(0, ALL_LIMITS);
   }
 
   @Test
   public void blockWhenMaxOutstandingFeeFineBalanceLimitIsExceeded() {
-    validateMaxOutstandingFeeFineBalanceBlockResponse(1, SINGLE_LIMIT, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxOutstandingFeeFineBalanceBlockResponse(1, SINGLE_LIMIT);
   }
 
   @Test
   public void blockWhenMaxOutstandingFeeFineBalanceLimitIsExceededAllLimitsExist() {
-    validateMaxOutstandingFeeFineBalanceBlockResponse(1, ALL_LIMITS, BLOCK_SHOULD_EXIST);
+    expectAllBlocks();
+    validateMaxOutstandingFeeFineBalanceBlockResponse(1, ALL_LIMITS);
   }
 
   @Test
   public void allLimitsAreExceeded() {
+    expectAllBlocks();
+    Arrays.stream(Condition.values())
+      .forEach(condition -> updateCondition(condition, expectBlockBorrowing, expectBlockRenewals,
+        expectBlockRequests));
+
     String loanId = randomId();
     createLimitsForAllConditions();
 
@@ -439,14 +485,18 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
       .withBlockBorrowing(!originalCondition.getBlockBorrowing())
       .withBlockRenewals(!originalCondition.getBlockRenewals())
       .withBlockRequests(!originalCondition.getBlockRequests())
-      .withMessage("Can't do anything");
+      .withMessage(EMPTY);
 
     waitFor(conditionsRepository.update(updatedCondition));
 
     String expectedResponse = toJson(
       new AutomatedPatronBlocks().withAutomatedPatronBlocks(singletonList(
         createBlock(condition, updatedCondition.getMessage(), updatedCondition.getBlockBorrowing(),
-          updatedCondition.getBlockRenewals(), updatedCondition.getBlockRequests()))));
+          updatedCondition.getBlockRenewals(), updatedCondition.getBlockRequests()))
+        .stream()
+        .filter(Objects::nonNull)
+        .collect(toList())
+      ));
 
     sendRequestAndCheckResult(expectedResponse);
 
@@ -486,6 +536,19 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
       ));
   }
 
+  private void updateCondition(Condition condition, boolean blockBorrowing, boolean blockRenewals,
+    boolean blockRequests) throws IllegalArgumentException {
+
+    PatronBlockCondition patronBlockCondition =
+      waitFor(conditionsRepository.get(condition.getId()))
+        .orElseThrow(() -> new IllegalArgumentException("Invalid condition ID"))
+        .withBlockBorrowing(blockBorrowing)
+        .withBlockRenewals(blockRenewals)
+        .withBlockRequests(blockRequests);
+
+    waitFor(conditionsRepository.update(patronBlockCondition));
+  }
+
   private String createLimit(Condition condition, String patronGroupId, double value) {
     PatronBlockLimit limit = new PatronBlockLimit()
       .withId(randomId())
@@ -516,15 +579,23 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     return waitFor(summaryRepository.save(userSummary));
   }
 
+  private AutomatedPatronBlock createBlock(Condition condition, String message) {
+    return createBlock(condition, message, expectBlockBorrowing, expectBlockRenewals, expectBlockRequests);
+  }
+
   private AutomatedPatronBlock createBlock(Condition condition, String message,
     boolean blockBorrowing, boolean blockRenewals, boolean blockRequests) {
 
-    return new AutomatedPatronBlock()
-      .withMessage(message)
-      .withBlockBorrowing(blockBorrowing)
-      .withBlockRenewals(blockRenewals)
-      .withBlockRequests(blockRequests)
-      .withPatronBlockConditionId(condition.getId());
+    if (blockBorrowing || blockRenewals || blockRequests) {
+      return new AutomatedPatronBlock()
+        .withMessage(message)
+        .withBlockBorrowing(blockBorrowing)
+        .withBlockRenewals(blockRenewals)
+        .withBlockRequests(blockRequests)
+        .withPatronBlockConditionId(condition.getId());
+    }
+
+    return null;
   }
 
   private void createLimitsForAllConditions() {
@@ -537,13 +608,13 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
     return toJson(
       new AutomatedPatronBlocks().withAutomatedPatronBlocks(
         Arrays.stream(conditions)
-          .map(condition -> createBlock(condition, EMPTY, false, false, false))
+          .map(condition -> createBlock(condition, EMPTY))
+          .filter(Objects::nonNull)
           .collect(toList())
       ));
   }
 
-  private String createLimitsAndBuildExpectedResponse(Condition condition, boolean singleLimit,
-    boolean blockShouldExist) {
+  private String createLimitsAndBuildExpectedResponse(Condition condition, boolean singleLimit) {
 
     int limitValue = LIMIT_VALUES.get(condition);
 
@@ -553,13 +624,18 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
       createLimitsForAllConditions();
     }
 
-    String expectedResponse;
-    if (blockShouldExist) {
-      expectedResponse = buildDefaultResponseFor(condition);
-    } else {
-      expectedResponse = buildDefaultResponseFor();
-    }
+    return buildDefaultResponseFor(condition);
+  }
 
-    return expectedResponse;
+  private void expectNoBlocks() {
+    expectBlockBorrowing = false;
+    expectBlockRenewals = false;
+    expectBlockRequests = false;
+  }
+
+  private void expectAllBlocks() {
+    expectBlockBorrowing = true;
+    expectBlockRenewals = true;
+    expectBlockRequests = true;
   }
 }

--- a/src/test/java/org/folio/rest/utils/EntityBuilder.java
+++ b/src/test/java/org/folio/rest/utils/EntityBuilder.java
@@ -1,5 +1,7 @@
 package org.folio.rest.utils;
 
+import static org.folio.util.UuidHelper.randomId;
+
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
@@ -8,11 +10,9 @@ import java.util.UUID;
 import org.folio.rest.jaxrs.model.OpenFeeFine;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
+import org.folio.util.UuidHelper;
 
 public class EntityBuilder {
-  private static String randomId() {
-    return UUID.randomUUID().toString();
-  }
 
   public static OpenLoan buildLoan(boolean recall, boolean itemLost, Date dueDate) {
     return buildLoan(randomId(), recall, itemLost, dueDate);


### PR DESCRIPTION
Resolves [MODPATBLK-34](https://issues.folio.org/browse/MODPATBLK-34).

Changes blocking by 'Maximum number of items charged out' condition - blocks borrowing when the limit is reached. 
All other blocks are enabled only when a limit is exceeded.