### PR TITLE
MODPATBLK-48 Fee/fine limit not being enforced properly for automated patron blocks

### DIFF
--- a/ramls/events/fee-fine-balance-changed.json
+++ b/ramls/events/fee-fine-balance-changed.json
@@ -5,7 +5,7 @@
   "description": "Fee/fine balance changed event",
   "properties": {
     "id": {
-      "description" : "A globally unique (UUID) identifier for the event",
+      "description" : "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },

--- a/ramls/events/fee-fine-balance-changed.json
+++ b/ramls/events/fee-fine-balance-changed.json
@@ -4,6 +4,11 @@
   "javaInterfaces" : ["org.folio.domain.Event"],
   "description": "Fee/fine balance changed event",
   "properties": {
+    "id": {
+      "description" : "A globally unique (UUID) identifier for the event",
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
+    },
     "feeFineId": {
       "description": "Unique ID a fee/fine",
       "type": "string",
@@ -28,6 +33,12 @@
       "description": "Current balance of a fee/fine",
       "type": "number",
       "javaType" : "java.math.BigDecimal"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/events/item-checked-in.json
+++ b/ramls/events/item-checked-in.json
@@ -4,6 +4,11 @@
   "javaInterfaces" : ["org.folio.domain.Event"],
   "description": "Item checked in event",
   "properties": {
+    "id": {
+      "description" : "A globally unique (UUID) identifier for the event",
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
+    },
     "userId": {
       "description": "Unique ID of a user",
       "type": "string",
@@ -18,6 +23,12 @@
       "description": "Loan return date",
       "type": "string",
       "format": "date-time"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/events/item-checked-in.json
+++ b/ramls/events/item-checked-in.json
@@ -5,7 +5,7 @@
   "description": "Item checked in event",
   "properties": {
     "id": {
-      "description" : "A globally unique (UUID) identifier for the event",
+      "description" : "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },

--- a/ramls/events/item-checked-out.json
+++ b/ramls/events/item-checked-out.json
@@ -5,7 +5,7 @@
   "description": "Item checked out event",
   "properties": {
     "id": {
-      "description" : "A globally unique (UUID) identifier for the event",
+      "description" : "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },

--- a/ramls/events/item-checked-out.json
+++ b/ramls/events/item-checked-out.json
@@ -4,6 +4,11 @@
   "javaInterfaces" : ["org.folio.domain.Event"],
   "description": "Item checked out event",
   "properties": {
+    "id": {
+      "description" : "A globally unique (UUID) identifier for the event",
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
+    },
     "userId": {
       "description": "ID of the user that checked out an item",
       "type": "string",
@@ -18,6 +23,12 @@
       "description": "Due date of the loan",
       "type": "string",
       "format": "date-time"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/events/item-claimed-returned.json
+++ b/ramls/events/item-claimed-returned.json
@@ -5,7 +5,7 @@
   "description": "Item claimed returned event",
   "properties": {
     "id": {
-      "description" : "A globally unique (UUID) identifier for the event",
+      "description" : "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },

--- a/ramls/events/item-claimed-returned.json
+++ b/ramls/events/item-claimed-returned.json
@@ -4,6 +4,11 @@
   "javaInterfaces" : ["org.folio.domain.Event"],
   "description": "Item claimed returned event",
   "properties": {
+    "id": {
+      "description" : "A globally unique (UUID) identifier for the event",
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
+    },
     "userId": {
       "description": "ID of the user the item was charged out to",
       "type": "string",
@@ -13,6 +18,12 @@
       "description": "ID of the loan associated with the item",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/events/item-declared-lost.json
+++ b/ramls/events/item-declared-lost.json
@@ -4,6 +4,11 @@
   "javaInterfaces" : ["org.folio.domain.Event"],
   "description": "Item declared lost event",
   "properties": {
+    "id": {
+      "description" : "A globally unique (UUID) identifier for the event",
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
+    },
     "userId": {
       "description": "ID of the user that declared an item lost",
       "type": "string",
@@ -13,6 +18,12 @@
       "description": "ID of the loan associated with a lost item",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/events/item-declared-lost.json
+++ b/ramls/events/item-declared-lost.json
@@ -5,7 +5,7 @@
   "description": "Item declared lost event",
   "properties": {
     "id": {
-      "description" : "A globally unique (UUID) identifier for the event",
+      "description" : "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },

--- a/ramls/events/loan-due-date-changed.json
+++ b/ramls/events/loan-due-date-changed.json
@@ -5,7 +5,7 @@
   "description": "Loan due date changed event",
   "properties": {
     "id": {
-      "description" : "A globally unique (UUID) identifier for the event",
+      "description" : "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },

--- a/ramls/events/loan-due-date-changed.json
+++ b/ramls/events/loan-due-date-changed.json
@@ -4,6 +4,11 @@
   "javaInterfaces" : ["org.folio.domain.Event"],
   "description": "Loan due date changed event",
   "properties": {
+    "id": {
+      "description" : "A globally unique (UUID) identifier for the event",
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
+    },
     "userId": {
       "description": "Unique ID of the user the loan was created for",
       "type": "string",
@@ -22,6 +27,12 @@
     "dueDateChangedByRecall": {
       "description": "Indicates if due date was changed as a result of a recall",
       "type": "boolean"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/domain/Event.java
+++ b/src/main/java/org/folio/domain/Event.java
@@ -1,4 +1,6 @@
 package org.folio.domain;
 
 public interface Event {
+  String getId();
+  String getUserId();
 }

--- a/src/main/java/org/folio/domain/Event.java
+++ b/src/main/java/org/folio/domain/Event.java
@@ -1,6 +1,9 @@
 package org.folio.domain;
 
+import org.folio.rest.jaxrs.model.Metadata;
+
 public interface Event {
   String getId();
   String getUserId();
+  Metadata getMetadata();
 }

--- a/src/main/java/org/folio/domain/EventType.java
+++ b/src/main/java/org/folio/domain/EventType.java
@@ -11,13 +11,13 @@ import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
 import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
 
 public enum EventType {
-  FEE_FINE_BALANCE_CHANGED(FeeFineBalanceChangedEvent.class, "fee_fine_balance_changed_event"),
-  ITEM_CHECKED_OUT(ItemCheckedOutEvent.class, "item_checked_out_event"),
-  ITEM_CHECKED_IN(ItemCheckedInEvent.class, "item_checked_in_event"),
-  ITEM_DECLARED_LOST(ItemDeclaredLostEvent.class, "item_declared_lost_event"),
-  ITEM_CLAIMED_RETURNED(ItemClaimedReturnedEvent.class, "item_claimed_returned_event"),
-  LOAN_DUE_DATE_CHANGED(LoanDueDateChangedEvent.class, "loan_due_date_changed_event"),
-  UNKNOWN(null, null);
+  FEE_FINE_BALANCE_CHANGED(FeeFineBalanceChangedEvent.class),
+  ITEM_CHECKED_OUT(ItemCheckedOutEvent.class),
+  ITEM_CHECKED_IN(ItemCheckedInEvent.class),
+  ITEM_DECLARED_LOST(ItemDeclaredLostEvent.class),
+  ITEM_CLAIMED_RETURNED(ItemClaimedReturnedEvent.class),
+  LOAN_DUE_DATE_CHANGED(LoanDueDateChangedEvent.class),
+  UNKNOWN(null);
 
   private static final Map<Class<? extends Event>, EventType> eventToType;
   static {
@@ -28,19 +28,13 @@ public enum EventType {
   }
 
   private final Class<? extends Event> eventClass;
-  private final String tableName;
 
-  EventType(Class<? extends Event> eventClass, String tableName) {
+  EventType(Class<? extends Event> eventClass) {
     this.eventClass = eventClass;
-    this.tableName = tableName;
   }
 
   public Class<? extends Event> getEventClass() {
     return eventClass;
-  }
-
-  public String getTableName() {
-    return tableName;
   }
 
   public static EventType getByEvent(Object event) {

--- a/src/main/java/org/folio/domain/EventType.java
+++ b/src/main/java/org/folio/domain/EventType.java
@@ -11,13 +11,13 @@ import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
 import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
 
 public enum EventType {
-  FEE_FINE_BALANCE_CHANGED(FeeFineBalanceChangedEvent.class),
-  ITEM_CHECKED_OUT(ItemCheckedOutEvent.class),
-  ITEM_CHECKED_IN(ItemCheckedInEvent.class),
-  ITEM_DECLARED_LOST(ItemDeclaredLostEvent.class),
-  ITEM_CLAIMED_RETURNED(ItemClaimedReturnedEvent.class),
-  LOAN_DUE_DATE_CHANGED(LoanDueDateChangedEvent.class),
-  UNKNOWN(null);
+  FEE_FINE_BALANCE_CHANGED(FeeFineBalanceChangedEvent.class, "fee_fine_balance_changed_event"),
+  ITEM_CHECKED_OUT(ItemCheckedOutEvent.class, "item_checked_out_event"),
+  ITEM_CHECKED_IN(ItemCheckedInEvent.class, "item_checked_in_event"),
+  ITEM_DECLARED_LOST(ItemDeclaredLostEvent.class, "item_declared_lost_event"),
+  ITEM_CLAIMED_RETURNED(ItemClaimedReturnedEvent.class, "item_claimed_returned_event"),
+  LOAN_DUE_DATE_CHANGED(LoanDueDateChangedEvent.class, "loan_due_date_changed_event"),
+  UNKNOWN(null, null);
 
   private static final Map<Class<? extends Event>, EventType> eventToType;
   static {
@@ -28,13 +28,19 @@ public enum EventType {
   }
 
   private final Class<? extends Event> eventClass;
+  private final String tableName;
 
-  EventType(Class<? extends Event> eventClass) {
+  EventType(Class<? extends Event> eventClass, String tableName) {
     this.eventClass = eventClass;
+    this.tableName = tableName;
   }
 
   public Class<? extends Event> getEventClass() {
     return eventClass;
+  }
+
+  public String getTableName() {
+    return tableName;
   }
 
   public static EventType getByEvent(Object event) {

--- a/src/main/java/org/folio/repository/BaseRepository.java
+++ b/src/main/java/org/folio/repository/BaseRepository.java
@@ -1,13 +1,10 @@
 package org.folio.repository;
 
-import static io.vertx.core.Future.succeededFuture;
-
 import java.util.List;
 import java.util.Optional;
 
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
-import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
@@ -22,8 +19,6 @@ import io.vertx.sqlclient.RowSet;
 
 public class BaseRepository<T> {
   private static final int DEFAULT_LIMIT = 100;
-  private static final String USER_ID_FIELD = "'userId'";
-  private static final String OPERATION_EQUALS = "=";
 
   private final PostgresClient pgClient;
   private final String tableName;
@@ -90,23 +85,6 @@ public class BaseRepository<T> {
     Promise<RowSet<Row>> promise = Promise.promise();
     pgClient.delete(tableName, id, promise);
     return promise.future().map(updateResult -> updateResult.rowCount() == 1);
-  }
-
-  public Future<Optional<T>> getByUserId(String userId) {
-    Criterion criterion = new Criterion(new Criteria()
-      .addField(USER_ID_FIELD)
-      .setOperation(OPERATION_EQUALS)
-      .setVal(userId)
-      .setJSONB(true));
-
-    return this.get(criterion)
-      .compose(results -> {
-        if (results.isEmpty()) {
-          return succeededFuture(Optional.empty());
-        }
-
-        return succeededFuture(Optional.ofNullable(results.get(0)));
-      });
   }
 
   /**

--- a/src/main/java/org/folio/repository/EventRepository.java
+++ b/src/main/java/org/folio/repository/EventRepository.java
@@ -1,11 +1,7 @@
 package org.folio.repository;
 
-import static io.vertx.core.Future.succeededFuture;
-
 import java.util.List;
-import java.util.Optional;
 
-import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;

--- a/src/main/java/org/folio/repository/EventRepository.java
+++ b/src/main/java/org/folio/repository/EventRepository.java
@@ -1,0 +1,31 @@
+package org.folio.repository;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.folio.rest.jaxrs.model.UserSummary;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Future;
+
+public class EventRepository<T> extends BaseRepository<T> {
+  private static final int NUMBER_OF_EVENTS_LIMIT = 10000;
+
+  public EventRepository(PostgresClient pgClient, String tableName, Class<T> entityType) {
+    super(pgClient, tableName, entityType);
+  }
+
+  public Future<List<T>> getByUserId(String userId) {
+    return this.get(new Criterion(new Criteria()
+      .addField("'userId'")
+      .setOperation("=")
+      .setVal(userId)
+      .setJSONB(true)
+    ).setLimit(new Limit(NUMBER_OF_EVENTS_LIMIT)));
+  }
+}

--- a/src/main/java/org/folio/repository/UserSummaryRepository.java
+++ b/src/main/java/org/folio/repository/UserSummaryRepository.java
@@ -35,22 +35,22 @@ public class UserSummaryRepository extends BaseRepository<UserSummary> {
     return super.update(entity, entity.getId());
   }
 
-  public Future<Optional<UserSummary>> getByUserId(String userId) {
-    Criterion criterion = new Criterion(new Criteria()
-        .addField(USER_ID_FIELD)
-        .setOperation(OPERATION_EQUALS)
-        .setVal(userId)
-        .setJSONB(true));
-
-    return this.get(criterion)
-      .compose(results -> {
-        if (results.isEmpty()) {
-          return succeededFuture(Optional.empty());
-        }
-
-        return succeededFuture(Optional.ofNullable(results.get(0)));
-      });
-  }
+//  public Future<Optional<UserSummary>> getByUserId(String userId) {
+//    Criterion criterion = new Criterion(new Criteria()
+//        .addField(USER_ID_FIELD)
+//        .setOperation(OPERATION_EQUALS)
+//        .setVal(userId)
+//        .setJSONB(true));
+//
+//    return this.get(criterion)
+//      .compose(results -> {
+//        if (results.isEmpty()) {
+//          return succeededFuture(Optional.empty());
+//        }
+//
+//        return succeededFuture(Optional.ofNullable(results.get(0)));
+//      });
+//  }
 
   public Future<UserSummary> findByUserIdOrBuildNew(String userId) {
     return getByUserId(userId)

--- a/src/main/java/org/folio/repository/UserSummaryRepository.java
+++ b/src/main/java/org/folio/repository/UserSummaryRepository.java
@@ -1,16 +1,21 @@
 package org.folio.repository;
 
+import static io.vertx.core.Future.succeededFuture;
 import static org.folio.util.UuidHelper.randomId;
 
 import java.util.Optional;
 
 import org.folio.rest.jaxrs.model.UserSummary;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 
 import io.vertx.core.Future;
 
 public class UserSummaryRepository extends BaseRepository<UserSummary> {
   public static final String USER_SUMMARY_TABLE_NAME = "user_summary";
+  private static final String USER_ID_FIELD = "'userId'";
+  private static final String OPERATION_EQUALS = "=";
   private static final String FIND_SUMMARY_BY_FEE_FINE_ID_QUERY_TEMPLATE =
     "openFeesFines == \"*\\\"feeFineId\\\": \\\"%s\\\"*\"";
 
@@ -42,10 +47,26 @@ public class UserSummaryRepository extends BaseRepository<UserSummary> {
       .map(result -> result.stream().findFirst());
   }
 
+  public Future<Optional<UserSummary>> getByUserId(String userId) {
+    Criterion criterion = new Criterion(new Criteria()
+      .addField(USER_ID_FIELD)
+      .setOperation(OPERATION_EQUALS)
+      .setVal(userId)
+      .setJSONB(true));
+
+    return this.get(criterion)
+      .compose(results -> {
+        if (results.isEmpty()) {
+          return succeededFuture(Optional.empty());
+        }
+
+        return succeededFuture(Optional.ofNullable(results.get(0)));
+      });
+  }
+
   private UserSummary buildEmptyUserSummary(String userId) {
     return new UserSummary()
       .withId(randomId())
       .withUserId(userId);
   }
-
 }

--- a/src/main/java/org/folio/repository/UserSummaryRepository.java
+++ b/src/main/java/org/folio/repository/UserSummaryRepository.java
@@ -1,21 +1,16 @@
 package org.folio.repository;
 
-import static io.vertx.core.Future.succeededFuture;
 import static org.folio.util.UuidHelper.randomId;
 
 import java.util.Optional;
 
 import org.folio.rest.jaxrs.model.UserSummary;
-import org.folio.rest.persist.Criteria.Criteria;
-import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 
 import io.vertx.core.Future;
 
 public class UserSummaryRepository extends BaseRepository<UserSummary> {
   public static final String USER_SUMMARY_TABLE_NAME = "user_summary";
-  private static final String USER_ID_FIELD = "'userId'";
-  private static final String OPERATION_EQUALS = "=";
   private static final String FIND_SUMMARY_BY_FEE_FINE_ID_QUERY_TEMPLATE =
     "openFeesFines == \"*\\\"feeFineId\\\": \\\"%s\\\"*\"";
 
@@ -34,23 +29,6 @@ public class UserSummaryRepository extends BaseRepository<UserSummary> {
   public Future<Boolean> update(UserSummary entity) {
     return super.update(entity, entity.getId());
   }
-
-//  public Future<Optional<UserSummary>> getByUserId(String userId) {
-//    Criterion criterion = new Criterion(new Criteria()
-//        .addField(USER_ID_FIELD)
-//        .setOperation(OPERATION_EQUALS)
-//        .setVal(userId)
-//        .setJSONB(true));
-//
-//    return this.get(criterion)
-//      .compose(results -> {
-//        if (results.isEmpty()) {
-//          return succeededFuture(Optional.empty());
-//        }
-//
-//        return succeededFuture(Optional.ofNullable(results.get(0)));
-//      });
-//  }
 
   public Future<UserSummary> findByUserIdOrBuildNew(String userId) {
     return getByUserId(userId)

--- a/src/main/java/org/folio/rest/handlers/EventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/EventHandler.java
@@ -1,15 +1,16 @@
 package org.folio.rest.handlers;
 
-import static org.folio.rest.tools.utils.TenantTool.calculateTenantId;
+import static org.folio.util.PostgresUtils.getPostgresClient;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.folio.domain.Event;
 import org.folio.domain.EventType;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.repository.UserSummaryRepository;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.service.EventService;
+import org.folio.service.UserSummaryService;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -21,14 +22,20 @@ import io.vertx.core.logging.LoggerFactory;
 public abstract class EventHandler<E extends Event> {
   protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   protected final UserSummaryRepository userSummaryRepository;
+  protected final EventService eventService;
+  protected final UserSummaryService userSummaryService;
 
-  public EventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
+  protected EventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     PostgresClient postgresClient = getPostgresClient(okapiHeaders, vertx);
     userSummaryRepository = new UserSummaryRepository(postgresClient);
+    eventService = new EventService(postgresClient);
+    userSummaryService = new UserSummaryService(postgresClient);
   }
 
-  public EventHandler(PostgresClient postgresClient) {
+  protected EventHandler(PostgresClient postgresClient) {
     userSummaryRepository = new UserSummaryRepository(postgresClient);
+    eventService = new EventService(postgresClient);
+    userSummaryService = new UserSummaryService(postgresClient);
   }
 
   /**
@@ -49,10 +56,4 @@ public abstract class EventHandler<E extends Event> {
         eventType, result.result());
     }
   }
-
-  protected PostgresClient getPostgresClient(Map<String, String> okapiHeaders, Vertx vertx) {
-    String tenantId = calculateTenantId(okapiHeaders.get(XOkapiHeaders.TENANT.toLowerCase()));
-    return PostgresClient.getInstance(vertx, tenantId);
-  }
-
 }

--- a/src/main/java/org/folio/rest/handlers/EventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/EventHandler.java
@@ -23,9 +23,8 @@ public abstract class EventHandler<E extends Event> {
   protected final UserSummaryRepository userSummaryRepository;
 
   public EventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
-    String tenantId = calculateTenantId(okapiHeaders.get(XOkapiHeaders.TENANT.toLowerCase()));
-    userSummaryRepository = new UserSummaryRepository(
-      PostgresClient.getInstance(vertx, tenantId));
+    PostgresClient postgresClient = getPostgresClient(okapiHeaders, vertx);
+    userSummaryRepository = new UserSummaryRepository(postgresClient);
   }
 
   public EventHandler(PostgresClient postgresClient) {
@@ -49,6 +48,11 @@ public abstract class EventHandler<E extends Event> {
       log.info("Event {} processed successfully. Affected user summary: {}",
         eventType, result.result());
     }
+  }
+
+  protected PostgresClient getPostgresClient(Map<String, String> okapiHeaders, Vertx vertx) {
+    String tenantId = calculateTenantId(okapiHeaders.get(XOkapiHeaders.TENANT.toLowerCase()));
+    return PostgresClient.getInstance(vertx, tenantId);
   }
 
 }

--- a/src/main/java/org/folio/rest/handlers/FeeFineBalanceChangedEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/FeeFineBalanceChangedEventHandler.java
@@ -2,85 +2,32 @@ package org.folio.rest.handlers;
 
 import static java.lang.String.format;
 
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.domain.EventType;
-import org.folio.domain.FeeFineType;
 import org.folio.exception.EntityNotFoundException;
-import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
-import org.folio.rest.jaxrs.model.OpenFeeFine;
-import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class FeeFineBalanceChangedEventHandler extends EventHandler<FeeFineBalanceChangedEvent> {
-  private static final String EVENT_TABLE_NAME = EventType.FEE_FINE_BALANCE_CHANGED.getTableName();
-  private static final List<String> LOST_ITEM_FEE_TYPE_IDS = Arrays.asList(
-    FeeFineType.LOST_ITEM_FEE.getId(),
-    FeeFineType.LOST_ITEM_PROCESSING_FEE.getId()
-  );
-
-  private final BaseRepository<FeeFineBalanceChangedEvent> eventRepository;
 
   public FeeFineBalanceChangedEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
-    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
-      FeeFineBalanceChangedEvent.class);
   }
 
   public FeeFineBalanceChangedEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
-    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
-      FeeFineBalanceChangedEvent.class);
   }
 
   @Override
   public Future<String> handle(FeeFineBalanceChangedEvent event) {
-    return eventRepository.save(event, UuidHelper.randomId())
+    return eventService.save(event)
       .compose(eventId -> getUserSummary(event))
-      .compose(summary -> updateUserSummary(summary, event))
+      .compose(summary -> userSummaryService.rebuild(summary.getUserId()))
       .onComplete(result -> logResult(result, event));
-  }
-
-  private Future<String> updateUserSummary(UserSummary userSummary,
-    FeeFineBalanceChangedEvent event) {
-
-    List<OpenFeeFine> openFeesFines = userSummary.getOpenFeesFines();
-
-    OpenFeeFine openFeeFine = openFeesFines.stream()
-      .filter(feeFine -> StringUtils.equals(feeFine.getFeeFineId(), event.getFeeFineId()))
-      .findFirst()
-      .orElseGet(() -> {
-        OpenFeeFine newFeeFine = new OpenFeeFine()
-          .withFeeFineId( event.getFeeFineId())
-          .withFeeFineTypeId(event.getFeeFineTypeId())
-          .withBalance(event.getBalance());
-        openFeesFines.add(newFeeFine);
-        return newFeeFine;
-      });
-
-    if (feeFineIsClosed(event)) {
-      openFeesFines.remove(openFeeFine);
-      removeLoanIfLastLostItemFeeWasClosed(userSummary, event);
-    } else {
-      openFeeFine.setBalance(event.getBalance());
-      openFeeFine.setLoanId(event.getLoanId());
-    }
-
-    return userSummaryRepository.upsert(userSummary, userSummary.getId());
-  }
-
-  private boolean feeFineIsClosed(FeeFineBalanceChangedEvent event) {
-    return BigDecimal.ZERO.compareTo(event.getBalance()) == 0;
   }
 
   private Future<UserSummary> getUserSummary(FeeFineBalanceChangedEvent event) {
@@ -93,33 +40,6 @@ public class FeeFineBalanceChangedEventHandler extends EventHandler<FeeFineBalan
     return userSummaryRepository.findByFeeFineId(feeFineId)
       .map(summary -> summary.orElseThrow(() -> new EntityNotFoundException(
         format("User summary with fee/fine %s was not found, event is ignored", feeFineId))));
-  }
-
-  private void removeLoanIfLastLostItemFeeWasClosed(UserSummary userSummary,
-    FeeFineBalanceChangedEvent event) {
-
-    if (!isLostItemFeeId(event.getFeeFineTypeId())) {
-      return;
-    }
-
-    userSummary.getOpenLoans().stream()
-      .filter(OpenLoan::getItemLost)
-      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
-      .findAny()
-      .ifPresent(loan -> {
-        boolean noLostItemFeesForLoanExist = userSummary.getOpenFeesFines().stream()
-          .filter(fee -> StringUtils.equals(fee.getLoanId(), event.getLoanId()))
-          .map(OpenFeeFine::getFeeFineTypeId)
-          .noneMatch(this::isLostItemFeeId);
-
-        if (noLostItemFeesForLoanExist) {
-          userSummary.getOpenLoans().remove(loan);
-        }
-      });
-  }
-
-  private boolean isLostItemFeeId(String feeFineTypeId) {
-    return LOST_ITEM_FEE_TYPE_IDS.contains(feeFineTypeId);
   }
 
 }

--- a/src/main/java/org/folio/rest/handlers/ItemCheckedInEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemCheckedInEventHandler.java
@@ -1,62 +1,27 @@
 package org.folio.rest.handlers;
 
-import static io.vertx.core.Future.succeededFuture;
-
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.domain.EventType;
-import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
-import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemCheckedInEventHandler extends EventHandler<ItemCheckedInEvent> {
-  private static final String EVENT_TABLE_NAME = EventType.ITEM_CHECKED_IN.getTableName();
-
-  private final BaseRepository<ItemCheckedInEvent> eventRepository;
 
   public ItemCheckedInEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
-    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
-      ItemCheckedInEvent.class);
   }
 
   public ItemCheckedInEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
-    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
-      ItemCheckedInEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemCheckedInEvent event) {
-    return eventRepository.save(event, UuidHelper.randomId())
-      .map(eventId -> event.getUserId())
-      .compose(userSummaryRepository::getByUserId)
-      .compose(optionalSummary -> optionalSummary
-        .map(summary -> updateUserSummary(summary, event))
-        .orElseGet(() -> {
-          log.info("Summary for user {} was not found. Event is ignored.", event.getUserId());
-          return succeededFuture();
-        }))
+    return eventService.save(event)
+      .compose(eventId -> userSummaryService.rebuild(event.getUserId()))
       .onComplete(result -> logResult(result, event));
-  }
-
-  private Future<String> updateUserSummary(UserSummary userSummary, ItemCheckedInEvent event) {
-    boolean loanRemoved = userSummary.getOpenLoans()
-      .removeIf(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()));
-
-    if (!loanRemoved) {
-      log.info("Open loan {} was not found in summary for user {}. Event is ignored.",
-        event.getLoanId(), event.getUserId());
-      return succeededFuture();
-    }
-
-    return userSummaryRepository.update(userSummary)
-      .map(userSummary.getId());
   }
 }

--- a/src/main/java/org/folio/rest/handlers/ItemCheckedInEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemCheckedInEventHandler.java
@@ -5,26 +5,37 @@ import static io.vertx.core.Future.succeededFuture;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.EventType;
+import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemCheckedInEventHandler extends EventHandler<ItemCheckedInEvent> {
+  private static final String EVENT_TABLE_NAME = EventType.ITEM_CHECKED_IN.getTableName();
+
+  private final BaseRepository<ItemCheckedInEvent> eventRepository;
 
   public ItemCheckedInEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
+    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
+      ItemCheckedInEvent.class);
   }
 
   public ItemCheckedInEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
+    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
+      ItemCheckedInEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemCheckedInEvent event) {
-    return succeededFuture(event.getUserId())
+    return eventRepository.save(event, UuidHelper.randomId())
+      .map(eventId -> event.getUserId())
       .compose(userSummaryRepository::getByUserId)
       .compose(optionalSummary -> optionalSummary
         .map(summary -> updateUserSummary(summary, event))

--- a/src/main/java/org/folio/rest/handlers/ItemCheckedOutEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemCheckedOutEventHandler.java
@@ -7,27 +7,38 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.EventType;
+import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemCheckedOutEventHandler extends EventHandler<ItemCheckedOutEvent> {
+  private static final String EVENT_TABLE_NAME = EventType.ITEM_CHECKED_OUT.getTableName();
+
+  private final BaseRepository<ItemCheckedOutEvent> eventRepository;
 
   public ItemCheckedOutEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
+    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
+      ItemCheckedOutEvent.class);
   }
 
   public ItemCheckedOutEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
+    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
+      ItemCheckedOutEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemCheckedOutEvent event) {
-    return userSummaryRepository.findByUserIdOrBuildNew(event.getUserId())
+    return eventRepository.save(event, UuidHelper.randomId())
+      .compose(eventId -> userSummaryRepository.findByUserIdOrBuildNew(event.getUserId()))
       .compose(summary -> updateUserSummary(summary, event))
       .onComplete(result -> logResult(result, event));
   }

--- a/src/main/java/org/folio/rest/handlers/ItemCheckedOutEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemCheckedOutEventHandler.java
@@ -1,67 +1,27 @@
 package org.folio.rest.handlers;
 
-import static io.vertx.core.Future.succeededFuture;
-import static org.folio.domain.EventType.ITEM_CHECKED_OUT;
-
-import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.domain.EventType;
-import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
-import org.folio.rest.jaxrs.model.OpenLoan;
-import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemCheckedOutEventHandler extends EventHandler<ItemCheckedOutEvent> {
-  private static final String EVENT_TABLE_NAME = EventType.ITEM_CHECKED_OUT.getTableName();
-
-  private final BaseRepository<ItemCheckedOutEvent> eventRepository;
 
   public ItemCheckedOutEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
-    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
-      ItemCheckedOutEvent.class);
   }
 
   public ItemCheckedOutEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
-    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
-      ItemCheckedOutEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemCheckedOutEvent event) {
-    return eventRepository.save(event, UuidHelper.randomId())
-      .compose(eventId -> userSummaryRepository.findByUserIdOrBuildNew(event.getUserId()))
-      .compose(summary -> updateUserSummary(summary, event))
+    return eventService.save(event)
+      .compose(eventId -> userSummaryService.rebuild(event.getUserId()))
       .onComplete(result -> logResult(result, event));
-  }
-
-  private Future<String> updateUserSummary(UserSummary userSummary,
-    ItemCheckedOutEvent event) {
-
-    List<OpenLoan> openLoans = userSummary.getOpenLoans();
-
-    if (openLoans.stream()
-      .noneMatch(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))) {
-
-      openLoans.add(new OpenLoan()
-        .withLoanId(event.getLoanId())
-        .withDueDate(event.getDueDate()));
-
-      return userSummaryRepository.upsert(userSummary, userSummary.getId());
-    }
-    else {
-      log.error("{} event is ignored, open loan ID {} already exists", ITEM_CHECKED_OUT.name(),
-        event.getLoanId());
-
-      return succeededFuture();
-    }
   }
 }

--- a/src/main/java/org/folio/rest/handlers/ItemClaimedReturnedEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemClaimedReturnedEventHandler.java
@@ -1,60 +1,27 @@
 package org.folio.rest.handlers;
 
-import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.domain.EventType;
-import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemClaimedReturnedEvent;
-import org.folio.rest.jaxrs.model.OpenLoan;
-import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemClaimedReturnedEventHandler extends EventHandler<ItemClaimedReturnedEvent> {
-  private static final String EVENT_TABLE_NAME = EventType.ITEM_CLAIMED_RETURNED.getTableName();
-
-  private final BaseRepository<ItemClaimedReturnedEvent> eventRepository;
 
   public ItemClaimedReturnedEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
-    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
-      ItemClaimedReturnedEvent.class);
   }
 
   public ItemClaimedReturnedEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
-    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
-      ItemClaimedReturnedEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemClaimedReturnedEvent event) {
-    return eventRepository.save(event, UuidHelper.randomId())
-      .compose(eventId -> userSummaryRepository.findByUserIdOrBuildNew(event.getUserId()))
-      .compose(summary -> updateUserSummary(summary, event))
+    return eventService.save(event)
+      .compose(eventId -> userSummaryService.rebuild(event.getUserId()))
       .onComplete(result -> logResult(result, event));
-  }
-
-  private Future<String> updateUserSummary(UserSummary userSummary, ItemClaimedReturnedEvent event) {
-    List<OpenLoan> openLoans = userSummary.getOpenLoans();
-
-    final OpenLoan openLoan = openLoans.stream()
-      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
-      .findFirst()
-      .orElseGet(() -> {
-        OpenLoan newOpenLoan = new OpenLoan().withLoanId(event.getLoanId());
-        openLoans.add(newOpenLoan);
-        return newOpenLoan;
-      });
-
-    openLoan.setItemClaimedReturned(true);
-    openLoan.setItemLost(false);
-
-    return userSummaryRepository.upsert(userSummary, userSummary.getId());
   }
 }

--- a/src/main/java/org/folio/rest/handlers/ItemClaimedReturnedEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemClaimedReturnedEventHandler.java
@@ -4,27 +4,38 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.EventType;
+import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemClaimedReturnedEvent;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemClaimedReturnedEventHandler extends EventHandler<ItemClaimedReturnedEvent> {
+  private static final String EVENT_TABLE_NAME = EventType.ITEM_CLAIMED_RETURNED.getTableName();
+
+  private final BaseRepository<ItemClaimedReturnedEvent> eventRepository;
 
   public ItemClaimedReturnedEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
+    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
+      ItemClaimedReturnedEvent.class);
   }
 
   public ItemClaimedReturnedEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
+    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
+      ItemClaimedReturnedEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemClaimedReturnedEvent event) {
-    return userSummaryRepository.findByUserIdOrBuildNew(event.getUserId())
+    return eventRepository.save(event, UuidHelper.randomId())
+      .compose(eventId -> userSummaryRepository.findByUserIdOrBuildNew(event.getUserId()))
       .compose(summary -> updateUserSummary(summary, event))
       .onComplete(result -> logResult(result, event));
   }

--- a/src/main/java/org/folio/rest/handlers/ItemDeclaredLostEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemDeclaredLostEventHandler.java
@@ -1,60 +1,27 @@
 package org.folio.rest.handlers;
 
-import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.domain.EventType;
-import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
-import org.folio.rest.jaxrs.model.OpenLoan;
-import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemDeclaredLostEventHandler extends EventHandler<ItemDeclaredLostEvent> {
-  private static final String EVENT_TABLE_NAME = EventType.ITEM_DECLARED_LOST.getTableName();
-
-  private final BaseRepository<ItemDeclaredLostEvent> eventRepository;
 
   public ItemDeclaredLostEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
-    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
-      ItemDeclaredLostEvent.class);
   }
 
   public ItemDeclaredLostEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
-    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
-      ItemDeclaredLostEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemDeclaredLostEvent event) {
-    return eventRepository.save(event, UuidHelper.randomId())
-      .compose(eventId -> userSummaryRepository.findByUserIdOrBuildNew(event.getUserId()))
-      .compose(summary -> updateUserSummary(summary, event))
+    return eventService.save(event)
+      .compose(eventId -> userSummaryService.rebuild(event.getUserId()))
       .onComplete(result -> logResult(result, event));
-  }
-
-  private Future<String> updateUserSummary(UserSummary userSummary, ItemDeclaredLostEvent event) {
-    List<OpenLoan> openLoans = userSummary.getOpenLoans();
-
-    final OpenLoan openLoan = openLoans.stream()
-      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
-      .findAny()
-      .orElseGet(() -> {
-        OpenLoan newOpenLoan = new OpenLoan().withLoanId(event.getLoanId());
-        openLoans.add(newOpenLoan);
-        return newOpenLoan;
-      });
-
-    openLoan.setItemLost(true);
-    openLoan.setItemClaimedReturned(false);
-
-    return userSummaryRepository.upsert(userSummary, userSummary.getId());
   }
 }

--- a/src/main/java/org/folio/rest/handlers/ItemDeclaredLostEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/ItemDeclaredLostEventHandler.java
@@ -4,27 +4,38 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.EventType;
+import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class ItemDeclaredLostEventHandler extends EventHandler<ItemDeclaredLostEvent> {
+  private static final String EVENT_TABLE_NAME = EventType.ITEM_DECLARED_LOST.getTableName();
+
+  private final BaseRepository<ItemDeclaredLostEvent> eventRepository;
 
   public ItemDeclaredLostEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
+    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
+      ItemDeclaredLostEvent.class);
   }
 
   public ItemDeclaredLostEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
+    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
+      ItemDeclaredLostEvent.class);
   }
 
   @Override
   public Future<String> handle(ItemDeclaredLostEvent event) {
-    return userSummaryRepository.findByUserIdOrBuildNew(event.getUserId())
+    return eventRepository.save(event, UuidHelper.randomId())
+      .compose(eventId -> userSummaryRepository.findByUserIdOrBuildNew(event.getUserId()))
       .compose(summary -> updateUserSummary(summary, event))
       .onComplete(result -> logResult(result, event));
   }

--- a/src/main/java/org/folio/rest/handlers/LoanDueDateChangedEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/LoanDueDateChangedEventHandler.java
@@ -1,33 +1,42 @@
 package org.folio.rest.handlers;
 
-import static io.vertx.core.Future.succeededFuture;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.EventType;
+import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class LoanDueDateChangedEventHandler extends EventHandler<LoanDueDateChangedEvent> {
+  private static final String EVENT_TABLE_NAME = EventType.LOAN_DUE_DATE_CHANGED.getTableName();
+
+  private final BaseRepository<LoanDueDateChangedEvent> eventRepository;
 
   public LoanDueDateChangedEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
+    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
+      LoanDueDateChangedEvent.class);
   }
 
   public LoanDueDateChangedEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
+    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
+      LoanDueDateChangedEvent.class);
   }
 
   @Override
   public Future<String> handle(LoanDueDateChangedEvent event) {
-    return succeededFuture(event.getUserId())
+    return eventRepository.save(event, UuidHelper.randomId())
+      .map(eventId -> event.getUserId())
       .compose(userSummaryRepository::findByUserIdOrBuildNew)
       .compose(summary -> updateUserSummary(summary, event))
       .onComplete(result -> logResult(result, event));

--- a/src/main/java/org/folio/rest/handlers/LoanDueDateChangedEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/LoanDueDateChangedEventHandler.java
@@ -1,65 +1,28 @@
 package org.folio.rest.handlers;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.domain.EventType;
-import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
-import org.folio.rest.jaxrs.model.OpenLoan;
-import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class LoanDueDateChangedEventHandler extends EventHandler<LoanDueDateChangedEvent> {
-  private static final String EVENT_TABLE_NAME = EventType.LOAN_DUE_DATE_CHANGED.getTableName();
-
-  private final BaseRepository<LoanDueDateChangedEvent> eventRepository;
 
   public LoanDueDateChangedEventHandler(Map<String, String> okapiHeaders, Vertx vertx) {
     super(okapiHeaders, vertx);
-    eventRepository = new BaseRepository<>(getPostgresClient(okapiHeaders, vertx), EVENT_TABLE_NAME,
-      LoanDueDateChangedEvent.class);
   }
 
   public LoanDueDateChangedEventHandler(PostgresClient postgresClient) {
     super(postgresClient);
-    eventRepository = new BaseRepository<>(postgresClient, EVENT_TABLE_NAME,
-      LoanDueDateChangedEvent.class);
   }
 
   @Override
   public Future<String> handle(LoanDueDateChangedEvent event) {
-    return eventRepository.save(event, UuidHelper.randomId())
+    return eventService.save(event)
       .map(eventId -> event.getUserId())
-      .compose(userSummaryRepository::findByUserIdOrBuildNew)
-      .compose(summary -> updateUserSummary(summary, event))
+      .compose(eventId -> userSummaryService.rebuild(event.getUserId()))
       .onComplete(result -> logResult(result, event));
-  }
-
-  private Future<String> updateUserSummary(UserSummary summary, LoanDueDateChangedEvent event) {
-    List<OpenLoan> openLoans = summary.getOpenLoans();
-
-    Optional<OpenLoan> loanMatch = openLoans.stream()
-      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
-      .findFirst();
-
-    if (loanMatch.isPresent()) {
-      OpenLoan loan = loanMatch.get();
-      loan.setDueDate(event.getDueDate());
-      loan.setRecall(event.getDueDateChangedByRecall());
-    } else {
-      openLoans.add(new OpenLoan()
-        .withLoanId(event.getLoanId())
-        .withDueDate(event.getDueDate())
-        .withRecall(event.getDueDateChangedByRecall()));
-    }
-
-    return userSummaryRepository.upsert(summary);
   }
 }

--- a/src/main/java/org/folio/rest/handlers/LoanDueDateChangedEventHandler.java
+++ b/src/main/java/org/folio/rest/handlers/LoanDueDateChangedEventHandler.java
@@ -22,7 +22,7 @@ public class LoanDueDateChangedEventHandler extends EventHandler<LoanDueDateChan
   public Future<String> handle(LoanDueDateChangedEvent event) {
     return eventService.save(event)
       .map(eventId -> event.getUserId())
-      .compose(eventId -> userSummaryService.rebuild(event.getUserId()))
+      .compose(userSummaryService::rebuild)
       .onComplete(result -> logResult(result, event));
   }
 }

--- a/src/main/java/org/folio/rest/impl/UserSummaryAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserSummaryAPI.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.lang.String.format;
+import static org.folio.util.PostgresUtils.getPostgresClient;
 import static org.folio.util.UuidUtil.isUuid;
 
 import java.util.Map;
@@ -27,7 +28,7 @@ public class UserSummaryAPI implements UserSummaryUserId {
       return;
     }
 
-    new UserSummaryService(okapiHeaders, vertxContext.owner()).getByUserId(userId)
+    new UserSummaryService(getPostgresClient(okapiHeaders, vertxContext.owner())).getByUserId(userId)
       .onSuccess(userSummary -> asyncResultHandler.handle(succeededFuture(
         UserSummaryUserId.GetUserSummaryByUserIdResponse.respond200WithApplicationJson(userSummary))))
       .onFailure(failure -> {

--- a/src/main/java/org/folio/service/EventService.java
+++ b/src/main/java/org/folio/service/EventService.java
@@ -2,23 +2,19 @@ package org.folio.service;
 
 import java.util.List;
 
-import org.folio.repository.BaseRepository;
+import org.folio.repository.EventRepository;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
 import org.folio.rest.jaxrs.model.ItemClaimedReturnedEvent;
 import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
 import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
-import org.folio.rest.persist.Criteria.Criteria;
-import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.util.UuidHelper;
 
 import io.vertx.core.Future;
 
 public class EventService {
-  private static final int NUMBER_OF_EVENTS_LIMIT = 10000;
 
   private static final String ITEM_CHECKED_OUT_EVENT_TABLE_NAME = "item_checked_out_event";
   private static final String ITEM_CHECKED_IN_EVENT_TABLE_NAME = "item_checked_in_event";
@@ -27,30 +23,30 @@ public class EventService {
   private static final String LOAN_DUE_DATE_CHANGED_EVENT_TABLE_NAME = "loan_due_date_changed_event";
   private static final String FEE_FINE_BALANCE_CHANGED_EVENT_TABLE_NAME = "fee_fine_balance_changed_event";
 
-  private final BaseRepository<ItemCheckedOutEvent> itemCheckedOutEventRepository;
-  private final BaseRepository<ItemCheckedInEvent> itemCheckedInEventRepository;
-  private final BaseRepository<ItemClaimedReturnedEvent> itemClaimedReturnedEventRepository;
-  private final BaseRepository<ItemDeclaredLostEvent> itemDeclaredLostEventRepository;
-  private final BaseRepository<LoanDueDateChangedEvent> loanDueDateChangedEventRepository;
-  private final BaseRepository<FeeFineBalanceChangedEvent> feeFineBalanceChangedEventRepository;
+  private final EventRepository<ItemCheckedOutEvent> itemCheckedOutEventRepository;
+  private final EventRepository<ItemCheckedInEvent> itemCheckedInEventRepository;
+  private final EventRepository<ItemClaimedReturnedEvent> itemClaimedReturnedEventRepository;
+  private final EventRepository<ItemDeclaredLostEvent> itemDeclaredLostEventRepository;
+  private final EventRepository<LoanDueDateChangedEvent> loanDueDateChangedEventRepository;
+  private final EventRepository<FeeFineBalanceChangedEvent> feeFineBalanceChangedEventRepository;
 
   public EventService(PostgresClient postgresClient) {
-    itemCheckedOutEventRepository = new BaseRepository<>(postgresClient,
+    itemCheckedOutEventRepository = new EventRepository<>(postgresClient,
       ITEM_CHECKED_OUT_EVENT_TABLE_NAME, ItemCheckedOutEvent.class);
 
-    itemCheckedInEventRepository = new BaseRepository<>(postgresClient,
+    itemCheckedInEventRepository = new EventRepository<>(postgresClient,
       ITEM_CHECKED_IN_EVENT_TABLE_NAME, ItemCheckedInEvent.class);
 
-    itemClaimedReturnedEventRepository = new BaseRepository<>(postgresClient,
+    itemClaimedReturnedEventRepository = new EventRepository<>(postgresClient,
       ITEM_DECLARED_LOST_EVENT_TABLE_NAME, ItemClaimedReturnedEvent.class);
 
-    itemDeclaredLostEventRepository = new BaseRepository<>(postgresClient,
+    itemDeclaredLostEventRepository = new EventRepository<>(postgresClient,
       ITEM_CLAIMED_RETURNED_EVENT_TABLE_NAME, ItemDeclaredLostEvent.class);
 
-    loanDueDateChangedEventRepository = new BaseRepository<>(postgresClient,
+    loanDueDateChangedEventRepository = new EventRepository<>(postgresClient,
       LOAN_DUE_DATE_CHANGED_EVENT_TABLE_NAME, LoanDueDateChangedEvent.class);
 
-    feeFineBalanceChangedEventRepository = new BaseRepository<>(postgresClient,
+    feeFineBalanceChangedEventRepository = new EventRepository<>(postgresClient,
       FEE_FINE_BALANCE_CHANGED_EVENT_TABLE_NAME, FeeFineBalanceChangedEvent.class);
   }
 
@@ -79,35 +75,26 @@ public class EventService {
   }
 
   public Future<List<ItemCheckedOutEvent>> getItemCheckedOutEvents(String userId) {
-    return itemCheckedOutEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+    return itemCheckedOutEventRepository.getByUserId(userId);
   }
 
   public Future<List<ItemCheckedInEvent>> getItemCheckedInEvents(String userId) {
-    return itemCheckedInEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+    return itemCheckedInEventRepository.getByUserId(userId);
   }
 
   public Future<List<ItemClaimedReturnedEvent>> getItemClaimedReturnedEvents(String userId) {
-    return itemClaimedReturnedEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+    return itemClaimedReturnedEventRepository.getByUserId(userId);
   }
 
   public Future<List<ItemDeclaredLostEvent>> getItemDeclaredLostEvents(String userId) {
-    return itemDeclaredLostEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+    return itemDeclaredLostEventRepository.getByUserId(userId);
   }
 
   public Future<List<LoanDueDateChangedEvent>> getLoanDueDateChangedEvents(String userId) {
-    return loanDueDateChangedEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+    return loanDueDateChangedEventRepository.getByUserId(userId);
   }
 
   public Future<List<FeeFineBalanceChangedEvent>> getFeeFineBalanceChangedEvents(String userId) {
-    return feeFineBalanceChangedEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
-  }
-
-  private Criterion buildFilterEventsByUserIdCriterion(String userId) {
-    return new Criterion(new Criteria()
-      .addField("'userId'")
-      .setOperation("=")
-      .setVal(userId)
-      .setJSONB(true)
-    ).setLimit(new Limit(NUMBER_OF_EVENTS_LIMIT));
+    return feeFineBalanceChangedEventRepository.getByUserId(userId);
   }
 }

--- a/src/main/java/org/folio/service/EventService.java
+++ b/src/main/java/org/folio/service/EventService.java
@@ -21,6 +21,13 @@ import io.vertx.core.Future;
 public class EventService {
   private static final int NUMBER_OF_EVENTS_LIMIT = 10000;
 
+  private static final String ITEM_CHECKED_OUT_EVENT_TABLE_NAME = "item_checked_out_event";
+  private static final String ITEM_CHECKED_IN_EVENT_TABLE_NAME = "item_checked_in_event";
+  private static final String ITEM_DECLARED_LOST_EVENT_TABLE_NAME = "item_declared_lost_event";
+  private static final String ITEM_CLAIMED_RETURNED_EVENT_TABLE_NAME = "item_claimed_returned_event";
+  private static final String LOAN_DUE_DATE_CHANGED_EVENT_TABLE_NAME = "loan_due_date_changed_event";
+  private static final String FEE_FINE_BALANCE_CHANGED_EVENT_TABLE_NAME = "fee_fine_balance_changed_event";
+
   private final BaseRepository<ItemCheckedOutEvent> itemCheckedOutEventRepository;
   private final BaseRepository<ItemCheckedInEvent> itemCheckedInEventRepository;
   private final BaseRepository<ItemClaimedReturnedEvent> itemClaimedReturnedEventRepository;
@@ -30,22 +37,22 @@ public class EventService {
 
   public EventService(PostgresClient postgresClient) {
     itemCheckedOutEventRepository = new BaseRepository<>(postgresClient,
-      EventType.ITEM_CHECKED_OUT.getTableName(), ItemCheckedOutEvent.class);
+      ITEM_CHECKED_OUT_EVENT_TABLE_NAME, ItemCheckedOutEvent.class);
 
     itemCheckedInEventRepository = new BaseRepository<>(postgresClient,
-      EventType.ITEM_CHECKED_IN.getTableName(), ItemCheckedInEvent.class);
+      ITEM_CHECKED_IN_EVENT_TABLE_NAME, ItemCheckedInEvent.class);
 
     itemClaimedReturnedEventRepository = new BaseRepository<>(postgresClient,
-      EventType.ITEM_CLAIMED_RETURNED.getTableName(), ItemClaimedReturnedEvent.class);
+      ITEM_DECLARED_LOST_EVENT_TABLE_NAME, ItemClaimedReturnedEvent.class);
 
     itemDeclaredLostEventRepository = new BaseRepository<>(postgresClient,
-      EventType.ITEM_DECLARED_LOST.getTableName(), ItemDeclaredLostEvent.class);
+      ITEM_CLAIMED_RETURNED_EVENT_TABLE_NAME, ItemDeclaredLostEvent.class);
 
     loanDueDateChangedEventRepository = new BaseRepository<>(postgresClient,
-      EventType.LOAN_DUE_DATE_CHANGED.getTableName(), LoanDueDateChangedEvent.class);
+      LOAN_DUE_DATE_CHANGED_EVENT_TABLE_NAME, LoanDueDateChangedEvent.class);
 
     feeFineBalanceChangedEventRepository = new BaseRepository<>(postgresClient,
-      EventType.FEE_FINE_BALANCE_CHANGED.getTableName(), FeeFineBalanceChangedEvent.class);
+      FEE_FINE_BALANCE_CHANGED_EVENT_TABLE_NAME, FeeFineBalanceChangedEvent.class);
   }
 
   public Future<String> save(ItemCheckedOutEvent event) {

--- a/src/main/java/org/folio/service/EventService.java
+++ b/src/main/java/org/folio/service/EventService.java
@@ -1,0 +1,107 @@
+package org.folio.service;
+
+import java.util.List;
+
+import org.folio.domain.EventType;
+import org.folio.repository.BaseRepository;
+import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
+import org.folio.rest.jaxrs.model.ItemClaimedReturnedEvent;
+import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
+import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.util.UuidHelper;
+
+import io.vertx.core.Future;
+
+public class EventService {
+  private static final int NUMBER_OF_EVENTS_LIMIT = 10000;
+
+  private final BaseRepository<ItemCheckedOutEvent> itemCheckedOutEventRepository;
+  private final BaseRepository<ItemCheckedInEvent> itemCheckedInEventRepository;
+  private final BaseRepository<ItemClaimedReturnedEvent> itemClaimedReturnedEventRepository;
+  private final BaseRepository<ItemDeclaredLostEvent> itemDeclaredLostEventRepository;
+  private final BaseRepository<LoanDueDateChangedEvent> loanDueDateChangedEventRepository;
+  private final BaseRepository<FeeFineBalanceChangedEvent> feeFineBalanceChangedEventRepository;
+
+  public EventService(PostgresClient postgresClient) {
+    itemCheckedOutEventRepository = new BaseRepository<>(postgresClient,
+      EventType.ITEM_CHECKED_OUT.getTableName(), ItemCheckedOutEvent.class);
+
+    itemCheckedInEventRepository = new BaseRepository<>(postgresClient,
+      EventType.ITEM_CHECKED_IN.getTableName(), ItemCheckedInEvent.class);
+
+    itemClaimedReturnedEventRepository = new BaseRepository<>(postgresClient,
+      EventType.ITEM_CLAIMED_RETURNED.getTableName(), ItemClaimedReturnedEvent.class);
+
+    itemDeclaredLostEventRepository = new BaseRepository<>(postgresClient,
+      EventType.ITEM_DECLARED_LOST.getTableName(), ItemDeclaredLostEvent.class);
+
+    loanDueDateChangedEventRepository = new BaseRepository<>(postgresClient,
+      EventType.LOAN_DUE_DATE_CHANGED.getTableName(), LoanDueDateChangedEvent.class);
+
+    feeFineBalanceChangedEventRepository = new BaseRepository<>(postgresClient,
+      EventType.FEE_FINE_BALANCE_CHANGED.getTableName(), FeeFineBalanceChangedEvent.class);
+  }
+
+  public Future<String> save(ItemCheckedOutEvent event) {
+    return itemCheckedOutEventRepository.save(event, UuidHelper.randomId());
+  }
+
+  public Future<String> save(ItemCheckedInEvent event) {
+    return itemCheckedInEventRepository.save(event, UuidHelper.randomId());
+  }
+
+  public Future<String> save(ItemClaimedReturnedEvent event) {
+    return itemClaimedReturnedEventRepository.save(event, UuidHelper.randomId());
+  }
+
+  public Future<String> save(ItemDeclaredLostEvent event) {
+    return itemDeclaredLostEventRepository.save(event, UuidHelper.randomId());
+  }
+
+  public Future<String> save(LoanDueDateChangedEvent event) {
+    return loanDueDateChangedEventRepository.save(event, UuidHelper.randomId());
+  }
+
+  public Future<String> save(FeeFineBalanceChangedEvent event) {
+    return feeFineBalanceChangedEventRepository.save(event, UuidHelper.randomId());
+  }
+
+  public Future<List<ItemCheckedOutEvent>> getItemCheckedOutEvents(String userId) {
+    return itemCheckedOutEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+  }
+
+  public Future<List<ItemCheckedInEvent>> getItemCheckedInEvents(String userId) {
+    return itemCheckedInEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+  }
+
+  public Future<List<ItemClaimedReturnedEvent>> getItemClaimedReturnedEvents(String userId) {
+    return itemClaimedReturnedEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+  }
+
+  public Future<List<ItemDeclaredLostEvent>> getItemDeclaredLostEvents(String userId) {
+    return itemDeclaredLostEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+  }
+
+  public Future<List<LoanDueDateChangedEvent>> getLoanDueDateChangedEvents(String userId) {
+    return loanDueDateChangedEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+  }
+
+  public Future<List<FeeFineBalanceChangedEvent>> getFeeFineBalanceChangedEvents(String userId) {
+    return feeFineBalanceChangedEventRepository.get(buildFilterEventsByUserIdCriterion(userId));
+  }
+
+  private Criterion buildFilterEventsByUserIdCriterion(String userId) {
+    return new Criterion(new Criteria()
+      .addField("'userId'")
+      .setOperation("=")
+      .setVal(userId)
+      .setJSONB(true)
+    ).setLimit(new Limit(NUMBER_OF_EVENTS_LIMIT));
+  }
+}

--- a/src/main/java/org/folio/service/EventService.java
+++ b/src/main/java/org/folio/service/EventService.java
@@ -2,7 +2,6 @@ package org.folio.service;
 
 import java.util.List;
 
-import org.folio.domain.EventType;
 import org.folio.repository.BaseRepository;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedInEvent;

--- a/src/main/java/org/folio/service/PatronBlocksService.java
+++ b/src/main/java/org/folio/service/PatronBlocksService.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import org.folio.domain.ActionBlocks;
 import org.folio.repository.PatronBlockConditionsRepository;
 import org.folio.repository.PatronBlockLimitsRepository;
-import org.folio.repository.UserSummaryRepository;
 import org.folio.rest.client.CirculationStorageClient;
 import org.folio.rest.client.UsersClient;
 import org.folio.rest.jaxrs.model.AutomatedPatronBlock;
@@ -42,7 +41,6 @@ public class PatronBlocksService {
 
   private static final String DEFAULT_ERROR_MESSAGE = "Failed to calculate automated patron blocks";
 
-  private final UserSummaryRepository userSummaryRepository;
   private final UserSummaryService userSummaryService;
   private final PatronBlockConditionsRepository conditionsRepository;
   private final PatronBlockLimitsRepository limitsRepository;
@@ -53,7 +51,6 @@ public class PatronBlocksService {
   public PatronBlocksService(Map<String, String> okapiHeaders, Vertx vertx) {
     String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(TENANT));
     PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
-    userSummaryRepository = new UserSummaryRepository(postgresClient);
     userSummaryService = new UserSummaryService(postgresClient);
     conditionsRepository = new PatronBlockConditionsRepository(postgresClient);
     limitsRepository = new PatronBlockLimitsRepository(postgresClient);

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -136,7 +136,8 @@ public class UserSummaryService {
     }
     else {
       return userSummaryRepository.delete(ctx.userSummary.getId())
-        .map(ctx.userSummary.getId());
+        .map(ctx.userSummary.getId())
+        .otherwise(ctx.userSummary.getId());
     }
   }
 
@@ -308,10 +309,10 @@ public class UserSummaryService {
   }
 
   private boolean isEmpty(UserSummary userSummary) {
-    if (userSummary != null) {
-      if (userSummary.getOpenLoans() != null && userSummary.getOpenFeesFines() != null) {
-        return userSummary.getOpenLoans().size() == 0 && userSummary.getOpenFeesFines().size() == 0;
-      }
+    if (userSummary != null && userSummary.getOpenLoans() != null &&
+      userSummary.getOpenFeesFines() != null) {
+
+        return userSummary.getOpenLoans().isEmpty() && userSummary.getOpenFeesFines().isEmpty();
     }
 
     return true;

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -1,31 +1,332 @@
 package org.folio.service;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
 import static java.lang.String.format;
-import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.domain.EventType.ITEM_CHECKED_IN;
+import static org.folio.domain.EventType.ITEM_CHECKED_OUT;
 
-import java.util.Map;
+import java.lang.invoke.MethodHandles;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.Event;
+import org.folio.domain.EventType;
+import org.folio.domain.FeeFineType;
 import org.folio.exception.EntityNotFoundInDbException;
 import org.folio.repository.UserSummaryRepository;
+import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
+import org.folio.rest.jaxrs.model.ItemClaimedReturnedEvent;
+import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
+import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.OpenFeeFine;
+import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.utils.TenantTool;
+import org.folio.util.AsyncProcessingContext;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.With;
 
 public class UserSummaryService {
-  private final UserSummaryRepository userSummaryRepository;
+  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public UserSummaryService(Map<String, String> okapiHeaders, Vertx vertx) {
-    String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(TENANT));
-    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+  private static final String FAILED_TO_REBUILD_USER_SUMMARY_ERROR_MESSAGE =
+    "Failed to rebuild user summary";
+  private static final List<String> LOST_ITEM_FEE_TYPE_IDS = Arrays.asList(
+    FeeFineType.LOST_ITEM_FEE.getId(),
+    FeeFineType.LOST_ITEM_PROCESSING_FEE.getId()
+  );
+
+  private final UserSummaryRepository userSummaryRepository;
+  private final EventService eventService;
+
+  public UserSummaryService(PostgresClient postgresClient) {
     userSummaryRepository = new UserSummaryRepository(postgresClient);
+    eventService = new EventService(postgresClient);
   }
 
   public Future<UserSummary> getByUserId(String userId) {
-    return userSummaryRepository.getByUserId(userId)
+    return this.rebuild(userId)
+      .compose(userSummaryId -> userSummaryRepository.getByUserId(userId))
       .map(optionalUserSummary -> optionalUserSummary.orElseThrow(() ->
         new EntityNotFoundInDbException(format("User summary for user ID %s not found", userId))));
+  }
+
+  public Future<String> rebuild(String userId) {
+    log.info(format("Rebuilding user summary for user ID %s", userId));
+
+    return userSummaryRepository.findByUserIdOrBuildNew(userId)
+      .map(userSummary -> new RebuildContext().withUserSummary(userSummary))
+      .compose(this::loadEventsToContext)
+      .compose(this::cleanUpUserSummary)
+      .compose(this::handleEventsInChronologicalOrder);
+  }
+
+  private Future<RebuildContext> loadEventsToContext(RebuildContext ctx) {
+    if (ctx.userSummary == null || ctx.userSummary.getUserId() == null) {
+      ctx.logFailedValidationError("loadEventsToContext");
+      return failedFuture(FAILED_TO_REBUILD_USER_SUMMARY_ERROR_MESSAGE);
+    }
+
+    String userId = ctx.userSummary.getUserId();
+
+    return succeededFuture(userId)
+      .compose(eventService::getItemCheckedOutEvents)
+      .map(ctx.events::addAll)
+      .map(userId)
+      .compose(eventService::getItemCheckedInEvents)
+      .map(ctx.events::addAll)
+      .map(userId)
+      .compose(eventService::getItemClaimedReturnedEvents)
+      .map(ctx.events::addAll)
+      .map(userId)
+      .compose(eventService::getItemDeclaredLostEvents)
+      .map(ctx.events::addAll)
+      .map(userId)
+      .compose(eventService::getLoanDueDateChangedEvents)
+      .map(ctx.events::addAll)
+      .map(userId)
+      .compose(eventService::getFeeFineBalanceChangedEvents)
+      .map(ctx.events::addAll)
+      .map(ctx);
+  }
+
+  private Future<RebuildContext> cleanUpUserSummary(RebuildContext ctx) {
+    if (ctx.userSummary == null) {
+      ctx.logFailedValidationError("cleanUpUserSummary");
+      return failedFuture(FAILED_TO_REBUILD_USER_SUMMARY_ERROR_MESSAGE);
+    }
+
+    ctx.userSummary.setOpenLoans(new ArrayList<>());
+    ctx.userSummary.setOpenFeesFines(new ArrayList<>());
+
+    return succeededFuture(ctx);
+  }
+
+  private Future<String> handleEventsInChronologicalOrder(RebuildContext ctx) {
+    if (ctx.userSummary == null || ctx.userSummary.getUserId() == null) {
+      ctx.logFailedValidationError("loadEventsToContext");
+      return failedFuture(FAILED_TO_REBUILD_USER_SUMMARY_ERROR_MESSAGE);
+    }
+
+    ctx.events.stream()
+      .sorted(Comparator.comparingLong(event -> Optional.of(event)
+        .map(Event::getMetadata)
+        .map(Metadata::getCreatedDate)
+        .map(Date::getTime)
+        .orElse(0L)))
+      .forEachOrdered(event -> handleEvent(ctx, event));
+
+    if (!isEmpty(ctx.userSummary)) {
+      return userSummaryRepository.upsert(ctx.userSummary, ctx.userSummary.getId());
+    }
+    else {
+      return userSummaryRepository.delete(ctx.userSummary.getId())
+        .map(ctx.userSummary.getId());
+    }
+  }
+
+  private void handleEvent(RebuildContext ctx, Event event) {
+    if (ctx.userSummary == null || event == null || EventType.getByEvent(event) == null ||
+      event.getMetadata() == null) {
+
+      ctx.logFailedValidationError("handleEvent");
+      return;
+    }
+
+    EventType eventType = EventType.getByEvent(event);
+
+    log.info(format("Processing event %s:%s (created at %s)", eventType.name(), event.getId(),
+      event.getMetadata().getCreatedDate()));
+
+    switch (eventType) {
+      case ITEM_CHECKED_OUT:
+        updateUserSummary(ctx.userSummary, (ItemCheckedOutEvent) event);
+        break;
+      case ITEM_CHECKED_IN:
+        updateUserSummary(ctx.userSummary, (ItemCheckedInEvent) event);
+        break;
+      case ITEM_CLAIMED_RETURNED:
+        updateUserSummary(ctx.userSummary, (ItemClaimedReturnedEvent) event);
+        break;
+      case ITEM_DECLARED_LOST:
+        updateUserSummary(ctx.userSummary, (ItemDeclaredLostEvent) event);
+        break;
+      case LOAN_DUE_DATE_CHANGED:
+        updateUserSummary(ctx.userSummary, (LoanDueDateChangedEvent) event);
+        break;
+      case FEE_FINE_BALANCE_CHANGED:
+        updateUserSummary(ctx.userSummary, (FeeFineBalanceChangedEvent) event);
+        break;
+    }
+  }
+
+  private void updateUserSummary(UserSummary userSummary, ItemCheckedOutEvent event) {
+    List<OpenLoan> openLoans = userSummary.getOpenLoans();
+
+    if (openLoans.stream()
+      .noneMatch(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))) {
+
+      openLoans.add(new OpenLoan()
+        .withLoanId(event.getLoanId())
+        .withDueDate(event.getDueDate()));
+    }
+    else {
+      log.error("Event {}:{} is ignored. Open loan {} already exists",
+        ITEM_CHECKED_OUT.name(), event.getId(), event.getLoanId());
+    }
+  }
+
+  private void updateUserSummary(UserSummary userSummary, ItemCheckedInEvent event) {
+    boolean loanRemoved = userSummary.getOpenLoans()
+      .removeIf(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()));
+
+    if (!loanRemoved) {
+      log.error("Event {}:{} is ignored. Open loan {} was not found for user {}",
+        ITEM_CHECKED_IN.name(), event.getId(), event.getLoanId(), event.getUserId());
+    }
+  }
+
+  private void updateUserSummary(UserSummary userSummary, ItemClaimedReturnedEvent event) {
+    List<OpenLoan> openLoans = userSummary.getOpenLoans();
+
+    final OpenLoan openLoan = openLoans.stream()
+      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
+      .findFirst()
+      .orElseGet(() -> {
+        OpenLoan newOpenLoan = new OpenLoan().withLoanId(event.getLoanId());
+        openLoans.add(newOpenLoan);
+        return newOpenLoan;
+      });
+
+    openLoan.setItemClaimedReturned(true);
+    openLoan.setItemLost(false);
+  }
+
+  private void updateUserSummary(UserSummary userSummary, ItemDeclaredLostEvent event) {
+    List<OpenLoan> openLoans = userSummary.getOpenLoans();
+
+    final OpenLoan openLoan = openLoans.stream()
+      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
+      .findAny()
+      .orElseGet(() -> {
+        OpenLoan newOpenLoan = new OpenLoan().withLoanId(event.getLoanId());
+        openLoans.add(newOpenLoan);
+        return newOpenLoan;
+      });
+
+    openLoan.setItemLost(true);
+    openLoan.setItemClaimedReturned(false);
+  }
+
+  private void updateUserSummary(UserSummary summary, LoanDueDateChangedEvent event) {
+    List<OpenLoan> openLoans = summary.getOpenLoans();
+
+    Optional<OpenLoan> loanMatch = openLoans.stream()
+      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
+      .findFirst();
+
+    if (loanMatch.isPresent()) {
+      OpenLoan loan = loanMatch.get();
+      loan.setDueDate(event.getDueDate());
+      loan.setRecall(event.getDueDateChangedByRecall());
+    } else {
+      openLoans.add(new OpenLoan()
+        .withLoanId(event.getLoanId())
+        .withDueDate(event.getDueDate())
+        .withRecall(event.getDueDateChangedByRecall()));
+    }
+  }
+
+  private void updateUserSummary(UserSummary userSummary, FeeFineBalanceChangedEvent event) {
+    List<OpenFeeFine> openFeesFines = userSummary.getOpenFeesFines();
+
+    OpenFeeFine openFeeFine = openFeesFines.stream()
+      .filter(feeFine -> StringUtils.equals(feeFine.getFeeFineId(), event.getFeeFineId()))
+      .findFirst()
+      .orElseGet(() -> {
+        OpenFeeFine newFeeFine = new OpenFeeFine()
+          .withFeeFineId( event.getFeeFineId())
+          .withFeeFineTypeId(event.getFeeFineTypeId())
+          .withBalance(event.getBalance());
+        openFeesFines.add(newFeeFine);
+        return newFeeFine;
+      });
+
+    if (feeFineIsClosed(event)) {
+      openFeesFines.remove(openFeeFine);
+      removeLoanIfLastLostItemFeeWasClosed(userSummary, event);
+    } else {
+      openFeeFine.setBalance(event.getBalance());
+      openFeeFine.setLoanId(event.getLoanId());
+    }
+  }
+
+  private boolean feeFineIsClosed(FeeFineBalanceChangedEvent event) {
+    return BigDecimal.ZERO.compareTo(event.getBalance()) == 0;
+  }
+
+  private void removeLoanIfLastLostItemFeeWasClosed(UserSummary userSummary,
+    FeeFineBalanceChangedEvent event) {
+
+    if (!isLostItemFeeId(event.getFeeFineTypeId())) {
+      return;
+    }
+
+    userSummary.getOpenLoans().stream()
+      .filter(OpenLoan::getItemLost)
+      .filter(loan -> StringUtils.equals(loan.getLoanId(), event.getLoanId()))
+      .findAny()
+      .ifPresent(loan -> {
+        boolean noLostItemFeesForLoanExist = userSummary.getOpenFeesFines().stream()
+          .filter(fee -> StringUtils.equals(fee.getLoanId(), event.getLoanId()))
+          .map(OpenFeeFine::getFeeFineTypeId)
+          .noneMatch(this::isLostItemFeeId);
+
+        if (noLostItemFeesForLoanExist) {
+          userSummary.getOpenLoans().remove(loan);
+        }
+      });
+  }
+
+  private boolean isLostItemFeeId(String feeFineTypeId) {
+    return LOST_ITEM_FEE_TYPE_IDS.contains(feeFineTypeId);
+  }
+
+  private boolean isEmpty(UserSummary userSummary) {
+    if (userSummary != null) {
+      if (userSummary.getOpenLoans() != null && userSummary.getOpenFeesFines() != null) {
+        return userSummary.getOpenLoans().size() == 0 && userSummary.getOpenFeesFines().size() == 0;
+      }
+    }
+
+    return true;
+  }
+
+  @With
+  @AllArgsConstructor
+  @NoArgsConstructor(force = true)
+  private static class RebuildContext extends AsyncProcessingContext {
+    final UserSummary userSummary;
+    final List<Event> events = new ArrayList<>();
+
+    @Override
+    protected String getName() {
+      return "user-summary-rebuild-context";
+    }
   }
 }

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -42,7 +42,7 @@ import lombok.NoArgsConstructor;
 import lombok.With;
 
 public class UserSummaryService {
-  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String FAILED_TO_REBUILD_USER_SUMMARY_ERROR_MESSAGE =
     "Failed to rebuild user summary";
@@ -131,7 +131,7 @@ public class UserSummaryService {
         .orElse(0L)))
       .forEachOrdered(event -> handleEvent(ctx, event));
 
-    if (!isEmpty(ctx.userSummary)) {
+    if (isNotEmpty(ctx.userSummary)) {
       return userSummaryRepository.upsert(ctx.userSummary, ctx.userSummary.getId());
     }
     else {
@@ -316,6 +316,10 @@ public class UserSummaryService {
     }
 
     return true;
+  }
+
+  private boolean isNotEmpty(UserSummary userSummary) {
+    return !isEmpty(userSummary);
   }
 
   @With

--- a/src/main/java/org/folio/util/AsyncProcessingContext.java
+++ b/src/main/java/org/folio/util/AsyncProcessingContext.java
@@ -1,0 +1,29 @@
+package org.folio.util;
+
+import static java.lang.String.format;
+
+import java.lang.invoke.MethodHandles;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public abstract class AsyncProcessingContext {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  protected abstract String getName();
+
+  public void logFailedValidationError(String failedStep, String additionalMessage) {
+    String message = format("Context '%s' is invalid, failed to perform '%s'", getName(),
+      failedStep);
+
+    if (additionalMessage != null) {
+      message += format(". %s", additionalMessage);
+    }
+
+    log.error(message);
+  }
+
+  public void logFailedValidationError(String failedStep) {
+    logFailedValidationError(failedStep, null);
+  }
+}

--- a/src/main/java/org/folio/util/PostgresUtils.java
+++ b/src/main/java/org/folio/util/PostgresUtils.java
@@ -1,10 +1,9 @@
 package org.folio.util;
 
-import static org.folio.rest.tools.utils.TenantTool.calculateTenantId;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Map;
 
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.persist.PostgresClient;
 
 import io.vertx.core.Vertx;
@@ -13,7 +12,6 @@ public class PostgresUtils {
   private PostgresUtils() { }
 
   public static PostgresClient getPostgresClient(Map<String, String> okapiHeaders, Vertx vertx) {
-    String tenantId = calculateTenantId(okapiHeaders.get(XOkapiHeaders.TENANT.toLowerCase()));
-    return PostgresClient.getInstance(vertx, tenantId);
+    return PostgresClient.getInstance(vertx, tenantId(okapiHeaders));
   }
 }

--- a/src/main/java/org/folio/util/PostgresUtils.java
+++ b/src/main/java/org/folio/util/PostgresUtils.java
@@ -1,0 +1,17 @@
+package org.folio.util;
+
+import static org.folio.rest.tools.utils.TenantTool.calculateTenantId;
+
+import java.util.Map;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Vertx;
+
+public class PostgresUtils {
+  public static PostgresClient getPostgresClient(Map<String, String> okapiHeaders, Vertx vertx) {
+    String tenantId = calculateTenantId(okapiHeaders.get(XOkapiHeaders.TENANT.toLowerCase()));
+    return PostgresClient.getInstance(vertx, tenantId);
+  }
+}

--- a/src/main/java/org/folio/util/PostgresUtils.java
+++ b/src/main/java/org/folio/util/PostgresUtils.java
@@ -10,6 +10,8 @@ import org.folio.rest.persist.PostgresClient;
 import io.vertx.core.Vertx;
 
 public class PostgresUtils {
+  private PostgresUtils() { }
+
   public static PostgresClient getPostgresClient(Map<String, String> okapiHeaders, Vertx vertx) {
     String tenantId = calculateTenantId(okapiHeaders.get(XOkapiHeaders.TENANT.toLowerCase()));
     return PostgresClient.getInstance(vertx, tenantId);

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -9,27 +9,75 @@
   "tables": [
     {
       "tableName": "fee_fine_balance_changed_event",
-      "withMetadata": true
+      "withMetadata": true,
+      "index": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "item_checked_out_event",
-      "withMetadata": true
+      "withMetadata": true,
+      "index": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "item_checked_in_event",
-      "withMetadata": true
+      "withMetadata": true,
+      "index": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "item_declared_lost_event",
-      "withMetadata": true
+      "withMetadata": true,
+      "index": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "item_claimed_returned_event",
-      "withMetadata": true
+      "withMetadata": true,
+      "index": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "loan_due_date_changed_event",
-      "withMetadata": true
+      "withMetadata": true,
+      "index": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "user_summary",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -8,6 +8,30 @@
   ],
   "tables": [
     {
+      "tableName": "fee_fine_balance_changed_event",
+      "withMetadata": true
+    },
+    {
+      "tableName": "item_checked_out_event",
+      "withMetadata": true
+    },
+    {
+      "tableName": "item_checked_in_event",
+      "withMetadata": true
+    },
+    {
+      "tableName": "item_declared_lost_event",
+      "withMetadata": true
+    },
+    {
+      "tableName": "item_claimed_returned_event",
+      "withMetadata": true
+    },
+    {
+      "tableName": "loan_due_date_changed_event",
+      "withMetadata": true
+    },
+    {
       "tableName": "user_summary",
       "withMetadata": true,
       "uniqueIndex": [

--- a/src/test/java/org/folio/rest/TestBase.java
+++ b/src/test/java/org/folio/rest/TestBase.java
@@ -10,14 +10,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static java.lang.String.format;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import org.awaitility.Awaitility;
 import org.folio.rest.client.TenantClient;
@@ -177,21 +174,5 @@ public class TestBase {
 
   protected static String toJson(Object event) {
     return JsonObject.mapFrom(event).encodePrettily();
-  }
-
-  protected <T> List<T> fillListOfSize(T object, int listSize) {
-    List<T> list = new ArrayList<>();
-    for (int i = 0; i < listSize; i++) {
-      list.add(object);
-    }
-    return list;
-  }
-
-  protected <T> List<T> fillListOfSize(Supplier<T> supplier, int listSize) {
-    List<T> list = new ArrayList<>();
-    for (int i = 0; i < listSize; i++) {
-      list.add(supplier.get());
-    }
-    return list;
   }
 }

--- a/src/test/java/org/folio/rest/utils/EntityBuilder.java
+++ b/src/test/java/org/folio/rest/utils/EntityBuilder.java
@@ -5,12 +5,17 @@ import static org.folio.util.UuidHelper.randomId;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
+import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
+import org.folio.rest.jaxrs.model.ItemClaimedReturnedEvent;
+import org.folio.rest.jaxrs.model.ItemDeclaredLostEvent;
+import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
+import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.OpenFeeFine;
 import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
-import org.folio.util.UuidHelper;
 
 public class EntityBuilder {
 
@@ -40,5 +45,70 @@ public class EntityBuilder {
       .withUserId(userId)
       .withOpenFeesFines(feesFines)
       .withOpenLoans(openLoans);
+  }
+
+  public static Metadata buildDefaultMetadata() {
+    return new Metadata().withCreatedDate(new Date());
+  }
+
+  public static ItemCheckedOutEvent buildItemCheckedOutEvent(String userId, String loanId,
+    Date dueDate) {
+
+    return new ItemCheckedOutEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withDueDate(dueDate)
+      .withMetadata(buildDefaultMetadata());
+  }
+
+  public static ItemCheckedInEvent buildItemCheckedInEvent(String userId, String loanId,
+    Date returnDate) {
+
+    return new ItemCheckedInEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withReturnDate(returnDate)
+      .withMetadata(buildDefaultMetadata());
+  }
+
+  public static ItemClaimedReturnedEvent buildItemClaimedReturnedEvent(String userId,
+    String loanId) {
+
+    return new ItemClaimedReturnedEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withMetadata(buildDefaultMetadata());
+  }
+
+  public static ItemDeclaredLostEvent buildItemDeclaredLostEvent(String userId,
+    String loanId) {
+
+    return new ItemDeclaredLostEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withMetadata(buildDefaultMetadata());
+  }
+
+  public static FeeFineBalanceChangedEvent buildFeeFineBalanceChangedEvent(String userId,
+    String loanId, String feeFineId, String feeFineTypeId, BigDecimal balance) {
+
+    return new FeeFineBalanceChangedEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withFeeFineId(feeFineId)
+      .withFeeFineTypeId(feeFineTypeId)
+      .withBalance(balance)
+      .withMetadata(buildDefaultMetadata());
+  }
+
+  public static LoanDueDateChangedEvent buildLoanDueDateChangedEvent(String userId,
+    String loanId, Date dueDate, boolean dueDateChangedByRecall) {
+
+    return new LoanDueDateChangedEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withDueDate(dueDate)
+      .withDueDateChangedByRecall(dueDateChangedByRecall)
+      .withMetadata(buildDefaultMetadata());
   }
 }


### PR DESCRIPTION
Resolves [MODPATBLK-48](https://issues.folio.org/browse/MODPATBLK-48).

### Purpose
When two fees/fines are created simultaneously (e.g. `lost item fee` and `lost item processing fee`), the same userSummary object is updated in the DB by two different instances of `mod-patronblocks`. This causes a race condition and only the last update is applied.

### Approach
To fix this we're not just updating `userSummary` when an event is processed, we're also storing all of the events and trigger `userSummary`'s rebuild after each event is saved into DB. In the scenario with two instances this means that the latest rebuild will see both events. 
Also, rebuild is performed every time `userSummary` is fetched by ID, so it's synchronized with the events even if it has been changed in the DB directly.