### PR TITLE
MODPATBLK-83 Patron with 4 items checked out not being blocked on SNAPSHOT when limit set to 1 for patron group

### DIFF
--- a/ramls/loan-policy.json
+++ b/ramls/loan-policy.json
@@ -16,7 +16,6 @@
     },
     "loansPolicy": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "profileId": {
           "type": "string",
@@ -89,11 +88,9 @@
     },
     "requestManagement": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "recalls": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "alternateGracePeriod": {
               "type": "object",
@@ -109,12 +106,21 @@
               "type": "object",
               "$ref": "period.json",
               "description": "Recall return interval"
+            },
+            "allowRecallsToExtendOverdueLoans": {
+              "type": "boolean",
+              "description": "Whether recalls are allowed to extend overdue loans",
+              "default": false
+            },
+            "alternateRecallReturnInterval": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate recall return interval for overdue loans"
             }
           }
         },
         "holds": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "alternateCheckoutLoanPeriod": {
               "type": "object",
@@ -134,7 +140,6 @@
         },
         "pages": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "alternateCheckoutLoanPeriod": {
               "type": "object",
@@ -159,7 +164,6 @@
       "readonly": true
     }
   },
-  "additionalProperties": false,
   "required": [
     "name",
     "loanable",

--- a/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
@@ -855,6 +855,9 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         .put("gracePeriod", new JsonObject()
           .put("duration", 0)
           .put("intervalId", "Minutes")))
+      .put("requestManagement", new JsonObject()
+        .put("recalls", new JsonObject()
+          .put("allowRecallsToExtendOverdueLoans", true)))
       .encodePrettily();
   }
 
@@ -865,6 +868,9 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         .put("gracePeriod", new JsonObject()
           .put("duration", 5)
           .put("intervalId", "Hours")))
+      .put("requestManagement", new JsonObject()
+        .put("recalls", new JsonObject()
+          .put("allowRecallsToExtendOverdueLoans", true)))
       .encodePrettily();
   }
 


### PR DESCRIPTION
## Purpose
- update loan-policy json schema with new properties;
- remove additional properties restrictions;

Resolves: [MODPATBLK-83](https://issues.folio.org/browse/MODPATBLK-83)