### PR TITLE
MODPATBLK-85 Add pubsub permissions to tenant API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -162,7 +162,12 @@
           "methods": [
             "POST"
           ],
-          "pathPattern": "/_/tenant"
+          "pathPattern": "/_/tenant",
+          "modulePermissions": [
+            "pubsub.event-types.post",
+            "pubsub.publishers.post",
+            "pubsub.subscribers.post"
+          ]
         },
         {
           "methods": [


### PR DESCRIPTION
Resolves [MODPATBLK-85](https://issues.folio.org/browse/MODPATBLK-85).

There are issues with deploying mod-patron-blocks on the folio-testing environment because of missing pubsub permissions. The module is unable to register event types in pubsub.

From Okapi logs:

> 2021-03-10T03:22:41,674 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [165079/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         Access requires permission: pubsub.event-types.post
> 2021-03-10T03:22:41,675 INFO  ProxyContext         165079/pubsub RES 403 5054us mod-authtoken-2.8.0-SNAPSHOT.88 http://10.36.1.62:9134/pubsub/event-types?
> 2021-03-10T03:22:41,676 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [353242/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         [][](user permissions) nor [](module permissions) do not contain pubsub.event-types.post
> 2021-03-10T03:22:41,676 INFO  ProxyContext         353242/pubsub RES 403 5827us mod-authtoken-2.8.0-SNAPSHOT.88 http://10.36.1.62:9134/pubsub/event-types?
> 2021-03-10T03:22:41,678 INFO  ProxyContext         051238/pubsub RES 403 6327us mod-authtoken-2.8.0-SNAPSHOT.88 http://10.36.1.62:9134/pubsub/event-types?
> 2021-03-10T03:22:41,678 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [353242/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         Access requires permission: pubsub.event-types.post
> 2021-03-10T03:22:41,678 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [051238/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         [][](user permissions) nor [](module permissions) do not contain pubsub.event-types.post
> 2021-03-10T03:22:41,678 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [051238/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         Access requires permission: pubsub.event-types.post
> 2021-03-10T03:22:41,679 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [116021/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         [][](user permissions) nor [](module permissions) do not contain pubsub.event-types.post
> 2021-03-10T03:22:41,680 INFO  ProxyContext         116021/pubsub RES 403 7553us mod-authtoken-2.8.0-SNAPSHOT.88 http://10.36.1.62:9134/pubsub/event-types?
> 2021-03-10T03:22:41,680 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [116021/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         Access requires permission: pubsub.event-types.post
> 2021-03-10T03:22:41,681 INFO  ProxyContext         078292/pubsub RES 403 8189us mod-authtoken-2.8.0-SNAPSHOT.88 http://10.36.1.62:9134/pubsub/event-types?
> 2021-03-10T03:22:41,682 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [078292/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         [][](user permissions) nor [](module permissions) do not contain pubsub.event-types.post
> 2021-03-10T03:22:41,682 INFO  DockerModuleHandle   mod-authtoken-2.8.0-SNAPSHOT.88 03:22:41 [078292/pubsub] [diku] [] [mod-authtoken] ERROR MainVerticle         Access requires permission: pubsub.event-types.post
> 2021-03-10T03:22:41,683 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] ERROR PubSubClientUtils    org.folio.util.pubsub.exceptions.ModuleRegistrationException: EventDescriptor was not registered for eventType: ITEM_CHECKED_OUT . Status code: 403
> 2021-03-10T03:22:41,685 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] INFO  PostgresClient       Successfully executed  CREATE TABLE IF NOT EXISTS diku_mod_patron_blocks.rmb_internal_index (   name text PRIMARY KEY,   def text NOT NULL,   remove boolean NOT NULL );
> 2021-03-10T03:22:41,685 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] INFO  PostgresClient       trying to execute: {} UPDATE diku_mod_patron_blocks.rmb_internal_index SET remove = TRUE;
> 2021-03-10T03:22:41,686 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] ERROR PubSubClientUtils    org.folio.util.pubsub.exceptions.ModuleRegistrationException: EventDescriptor was not registered for eventType: ITEM_CHECKED_IN . Status code: 403
> 2021-03-10T03:22:41,686 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] ERROR PubSubClientUtils    org.folio.util.pubsub.exceptions.ModuleRegistrationException: EventDescriptor was not registered for eventType: ITEM_DECLARED_LOST . Status code: 403
> 2021-03-10T03:22:41,686 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] ERROR PubSubClientUtils    org.folio.util.pubsub.exceptions.ModuleRegistrationException: EventDescriptor was not registered for eventType: LOAN_DUE_DATE_CHANGED . Status code: 403
> 2021-03-10T03:22:41,687 INFO  DockerModuleHandle   mod-patron-blocks-1.2.0-SNAPSHOT.49 03:22:41 [] [] [] [] ERROR PubSubClientUtils    org.folio.util.pubsub.exceptions.ModuleRegistrationException: EventDescriptor was not registered for eventType: FEE_FINE_BALANCE_CHANGED . Status code: 403
