### PR TITLE
MODPATBLK-92 Change limit for double values

### DIFF
--- a/src/main/java/org/folio/rest/impl/PatronBlockLimitsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PatronBlockLimitsAPI.java
@@ -29,7 +29,7 @@ public class PatronBlockLimitsAPI implements PatronBlockLimits {
     ImmutableList.of("cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a");
   private static final String VALUE_FIELD = "value";
   private static final double MIN_DOUBLE_LIMIT = 0.0;
-  private static final double MAX_DOUBLE_LIMIT = 9999.99;
+  private static final double MAX_DOUBLE_LIMIT = 999999.99;
   private static final int MIN_INT_LIMIT = 0;
   private static final int MAX_INT_LIMIT = 999999;
 

--- a/src/test/java/org/folio/rest/impl/PatronBlockLimitsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/PatronBlockLimitsAPITest.java
@@ -104,7 +104,7 @@ public class PatronBlockLimitsAPITest extends TestBase {
       .as(PatronBlockLimit.class);
 
     String message = getErrorMessage(actualLimit);
-    assertThat(message, is("Must be blank or a number from 0.00 to 9999.99"));
+    assertThat(message, is("Must be blank or a number from 0.00 to 999999.99"));
   }
 
   @Test

--- a/src/test/resources/patron-block-limits/limit_max_outstanding_feefine_balance_limit_out_of_range.json
+++ b/src/test/resources/patron-block-limits/limit_max_outstanding_feefine_balance_limit_out_of_range.json
@@ -2,5 +2,5 @@
   "id": "1de95200-72e4-4967-bdf8-257fb7554879",
   "patronGroupId": "e5b45031-a202-4abb-917b-e1df9346fe2c",
   "conditionId": "cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a",
-  "value": "10000.00"
+  "value": "1000000.00"
 }


### PR DESCRIPTION
Resolves [MODPATBLK-92](https://issues.folio.org/browse/MODPATBLK-92)

### Approach
Limit for double values is changed from 9999.99 to 999999.99.