### PR TITLE
MODPATBLK-93 Save "Grace period" at moment of checkout

### DIFF
--- a/ramls/events/item-checked-out.json
+++ b/ramls/events/item-checked-out.json
@@ -1,11 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "javaInterfaces" : ["org.folio.domain.Event"],
+  "javaInterfaces": [
+    "org.folio.domain.Event"
+  ],
   "description": "Item checked out event",
   "properties": {
     "id": {
-      "description" : "A globally unique identifier (UUID) for the event",
+      "description": "A globally unique identifier (UUID) for the event",
       "type": "string",
       "$ref": "../raml-util/schemas/uuid.schema"
     },
@@ -29,6 +31,19 @@
       "type": "object",
       "$ref": "../raml-util/schemas/metadata.schema",
       "readonly": true
+    },
+    "gracePeriod": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "Duration of grace period",
+          "type": "integer"
+        },
+        "intervalId": {
+          "description": "Type of grace period, e.g Month, Week, etc",
+          "type": "string"
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/ramls/userSummary.json
+++ b/ramls/userSummary.json
@@ -39,15 +39,33 @@
             "type": "boolean",
             "default": false
           },
-          "itemLost" : {
+          "itemLost": {
             "description": "Indicates if the item associated with the loan is in status 'Aged to lost' or 'Declared lost'",
             "type": "boolean",
             "default": false
           },
-          "itemClaimedReturned" : {
+          "itemClaimedReturned": {
             "description": "Indicates if the item associated with the loan is in status 'Claimed returned'",
             "type": "boolean",
             "default": false
+          },
+          "gracePeriod": {
+            "type": "object",
+            "properties": {
+              "duration": {
+                "description": "Duration of grace period",
+                "type": "integer"
+              },
+              "intervalId": {
+                "description": "Type of grace period, e.g Month, Week, etc",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "duration",
+              "intervalId"
+            ]
           }
         },
         "additionalProperties": false,

--- a/src/main/java/org/folio/rest/client/CirculationStorageClient.java
+++ b/src/main/java/org/folio/rest/client/CirculationStorageClient.java
@@ -3,7 +3,6 @@ package org.folio.rest.client;
 import java.util.Map;
 
 import org.folio.rest.jaxrs.model.Loan;
-import org.folio.rest.jaxrs.model.LoanPolicy;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;

--- a/src/main/java/org/folio/rest/client/CirculationStorageClient.java
+++ b/src/main/java/org/folio/rest/client/CirculationStorageClient.java
@@ -17,8 +17,4 @@ public class CirculationStorageClient extends OkapiClient {
   public Future<Loan> findLoanById(String loanId) {
     return fetchById("loan-storage/loans", loanId, Loan.class);
   }
-
-  public Future<LoanPolicy> findLoanPolicyById(String loanPolicyId) {
-    return fetchById("loan-policy-storage/loan-policies", loanPolicyId, LoanPolicy.class);
-  }
 }

--- a/src/main/java/org/folio/service/PatronBlocksService.java
+++ b/src/main/java/org/folio/service/PatronBlocksService.java
@@ -20,6 +20,7 @@ import org.folio.rest.client.CirculationStorageClient;
 import org.folio.rest.client.UsersClient;
 import org.folio.rest.jaxrs.model.AutomatedPatronBlock;
 import org.folio.rest.jaxrs.model.AutomatedPatronBlocks;
+import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.PatronBlockCondition;
 import org.folio.rest.jaxrs.model.PatronBlockLimit;
 import org.folio.rest.jaxrs.model.UserSummary;
@@ -126,10 +127,12 @@ public class PatronBlocksService {
 
     List<Future<LoanOverdueMinutes>> overdueMinutesFutures = new ArrayList<>();
 
-    ctx.userSummary.getOpenLoans().forEach(openLoan ->
+    ctx.userSummary.getOpenLoans().stream()
+      .filter(OpenLoan::getRecall)
+      .forEach(openLoan ->
       overdueMinutesFutures.add(
         circulationStorageClient.findLoanById(openLoan.getLoanId())
-          .compose(loan -> overduePeriodCalculatorService.getMinutes(loan, DateTime.now()))
+          .compose(loan -> overduePeriodCalculatorService.getMinutes(loan, DateTime.now(),openLoan.getGracePeriod()))
           .map(intValue -> new LoanOverdueMinutes(openLoan.getLoanId(), intValue))
       ));
 

--- a/src/main/java/org/folio/service/PatronBlocksService.java
+++ b/src/main/java/org/folio/service/PatronBlocksService.java
@@ -127,12 +127,12 @@ public class PatronBlocksService {
 
     List<Future<LoanOverdueMinutes>> overdueMinutesFutures = new ArrayList<>();
 
-    ctx.userSummary.getOpenLoans().stream()
-      .filter(OpenLoan::getRecall)
+    ctx.userSummary.getOpenLoans()
       .forEach(openLoan ->
       overdueMinutesFutures.add(
         circulationStorageClient.findLoanById(openLoan.getLoanId())
-          .compose(loan -> overduePeriodCalculatorService.getMinutes(loan, DateTime.now(),openLoan.getGracePeriod()))
+          .compose(loan -> overduePeriodCalculatorService.getMinutes(loan, DateTime.now(),
+            openLoan.getGracePeriod()))
           .map(intValue -> new LoanOverdueMinutes(openLoan.getLoanId(), intValue))
       ));
 

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -24,6 +24,7 @@ import org.folio.domain.EventType;
 import org.folio.domain.FeeFineType;
 import org.folio.exception.EntityNotFoundInDbException;
 import org.folio.repository.UserSummaryRepository;
+import org.folio.rest.client.CirculationStorageClient;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
 import org.folio.rest.jaxrs.model.ItemAgedToLostEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedInEvent;

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -229,7 +229,8 @@ public class UserSummaryService {
 
       openLoans.add(new OpenLoan()
         .withLoanId(event.getLoanId())
-        .withDueDate(event.getDueDate()));
+        .withDueDate(event.getDueDate())
+        .withGracePeriod(event.getGracePeriod()));
     } else {
       log.error("Event {}:{} is ignored. Open loan {} already exists",
         ITEM_CHECKED_OUT.name(), event.getId(), event.getLoanId());

--- a/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
@@ -168,7 +168,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().plusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(buildItemCheckedOutEvent(userId, loanId, dueDate)));
       });
@@ -229,7 +229,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().plusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
           buildItemCheckedOutEvent(userId, loanId, dueDate)));
@@ -289,7 +289,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().plusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
           buildItemCheckedOutEvent(userId, loanId, dueDate)));
@@ -347,7 +347,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().minusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(buildItemCheckedOutEvent(userId, loanId, dueDate)));
       });
@@ -633,7 +633,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().plusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
           buildItemCheckedOutEvent(userId, loanId, dueDate)));
@@ -774,7 +774,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().minusHours(6).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
           buildItemCheckedOutEvent(userId, loanId, dueDate)));
@@ -805,7 +805,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().plusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
           buildItemCheckedOutEvent(userId, loanId, dueDate)));
@@ -818,7 +818,7 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().plusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
           buildItemCheckedOutEvent(userId, loanId, dueDate)));

--- a/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
+++ b/src/test/java/org/folio/rest/impl/AutomatedPatronBlocksAPITest.java
@@ -15,7 +15,9 @@ import static org.folio.domain.Condition.MAX_OUTSTANDING_FEE_FINE_BALANCE;
 import static org.folio.domain.Condition.RECALL_OVERDUE_BY_MAX_NUMBER_OF_DAYS;
 import static org.folio.repository.PatronBlockLimitsRepository.PATRON_BLOCK_LIMITS_TABLE_NAME;
 import static org.folio.repository.UserSummaryRepository.USER_SUMMARY_TABLE_NAME;
+import static org.folio.rest.utils.EntityBuilder.buildEmptyGracePeriod;
 import static org.folio.rest.utils.EntityBuilder.buildFeeFineBalanceChangedEvent;
+import static org.folio.rest.utils.EntityBuilder.buildGracePeriod;
 import static org.folio.rest.utils.EntityBuilder.buildItemAgedToLostEvent;
 import static org.folio.rest.utils.EntityBuilder.buildItemCheckedOutEvent;
 import static org.folio.rest.utils.EntityBuilder.buildItemClaimedReturnedEvent;
@@ -714,7 +716,8 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         stubLoan(loanId, dueDate, false);
 
         waitFor(itemCheckedOutEventHandler.handle(
-          buildItemCheckedOutEvent(userId, loanId, dueDate)));
+          buildItemCheckedOutEvent(userId, loanId, dueDate,
+            buildGracePeriod(3,"Weeks"))));
       });
 
     String expectedResponse = createLimitsAndBuildExpectedResponse(condition, true);
@@ -738,10 +741,10 @@ public class AutomatedPatronBlocksAPITest extends TestBase {
         String loanId = randomId();
         Date dueDate = now().minusHours(1).toDate();
 
-        stubLoan(loanId, dueDate, false);
+        stubLoan(loanId, dueDate, true);
 
         waitFor(itemCheckedOutEventHandler.handle(
-          buildItemCheckedOutEvent(userId, loanId, dueDate)));
+          buildItemCheckedOutEvent(userId, loanId, dueDate, buildEmptyGracePeriod())));
       });
 
     String expectedResponse = createLimitsAndBuildExpectedResponse(condition, true);

--- a/src/test/java/org/folio/rest/utils/EntityBuilder.java
+++ b/src/test/java/org/folio/rest/utils/EntityBuilder.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.folio.domain.SynchronizationStatus;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
+import org.folio.rest.jaxrs.model.GracePeriod;
 import org.folio.rest.jaxrs.model.ItemAgedToLostEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedInEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
@@ -62,6 +63,27 @@ public class EntityBuilder {
       .withLoanId(loanId)
       .withDueDate(dueDate)
       .withMetadata(buildDefaultMetadata());
+  }
+
+  public static ItemCheckedOutEvent buildItemCheckedOutEvent(String userId, String loanId,
+    Date dueDate,GracePeriod gracePeriod) {
+
+    return new ItemCheckedOutEvent()
+      .withUserId(userId)
+      .withLoanId(loanId)
+      .withDueDate(dueDate)
+      .withMetadata(buildDefaultMetadata())
+      .withGracePeriod(gracePeriod);
+  }
+
+  public static GracePeriod buildGracePeriod(Integer duration, String intervalId){
+    return new GracePeriod()
+      .withDuration(duration)
+      .withIntervalId(intervalId);
+  }
+
+  public static GracePeriod buildEmptyGracePeriod(){
+    return buildGracePeriod(0,"Months");
   }
 
   public static ItemCheckedInEvent buildItemCheckedInEvent(String userId, String loanId,


### PR DESCRIPTION
Resolves https://issues.folio.org/browse/MODPATBLK-93.

**Description**
To understand whether the loan is overdue, we first look at its due date. If due date is in the past, we're fetching loan policy to check grace period and then adjust the due date accordingly. Now, you may also notice that this particular loan doesn't have any recall requests, so in this case we don't even need to know whether it's overdue or not in order to calculate Max number of recalls block. 
We can pass grace period to mod-patron-blocks at the moment of check-out and store it so we don't have to fetch the loan policy later when automated blocks are requested. 
**Approach**
The grace period is now saved during the update of user summary with item checked out event, and so we do not need to make additional calls to get loan policy while calculating overdue minutes. A filter for loans that have not been recalled has been added also. 