### PR TITLE
MODPATBLK-106 Upgrade to RMB 33.1.3 and Log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.1.1</raml-module-builder.version>
+    <raml-module-builder.version>33.1.3</raml-module-builder.version>
     <vertx.version>4.1.5</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.0</rest-assured.version>


### PR DESCRIPTION
[MODPATBLK-106](https://issues.folio.org/browse/MODPATBLK-106)

Upgrade to RMB 33.1.3 which includes Log4j version with CVE-2021-44228 vulnerability fixed.