### PR TITLE
MODPATBLK-114 Cornell automated-patron-blocks performance issue

### DIFF
--- a/src/main/java/org/folio/service/PatronBlocksService.java
+++ b/src/main/java/org/folio/service/PatronBlocksService.java
@@ -124,6 +124,10 @@ public class PatronBlocksService {
   private Future<BlocksCalculationContext> addOverdueMinutesToContext(
     BlocksCalculationContext ctx) {
 
+    if (ctx.patronBlockLimits.isEmpty()) {
+      return Future.succeededFuture(ctx);
+    }
+
     List<Future<LoanOverdueMinutes>> overdueMinutesFutures = new ArrayList<>();
 
     ctx.userSummary.getOpenLoans().forEach(openLoan ->


### PR DESCRIPTION
Skip unnecessary loan calls to improve performance. Test showed the same slow request can be improved from 12s to less than 300ms.