### PR TITLE
MODPATBLK-121: Add maven-failsafe-plugin for ApiIT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,20 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>3.2.0</version>


### PR DESCRIPTION
Add maven-failsafe-plugin to execute the integration test
src/test/java/org/folio/rest/ApiIT.java