### PR TITLE
MODPATBLK-126 "Aged to lost item" that is "Declared lost", then renewed is still counted towards 'Maximum number of lost items'

### DIFF
--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -297,7 +297,7 @@ public class UserSummaryService {
       .ifPresentOrElse(openLoan -> {
         openLoan.setDueDate(event.getDueDate());
         openLoan.setRecall(event.getDueDateChangedByRecall());
-        if(!event.getDueDateChangedByRecall()){
+        if(Boolean.FALSE.equals(event.getDueDateChangedByRecall())){
           openLoan.setItemLost(false);
         }
       }, () -> logOpenLoanNotFound(event, event.getLoanId()));

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -297,6 +297,9 @@ public class UserSummaryService {
       .ifPresentOrElse(openLoan -> {
         openLoan.setDueDate(event.getDueDate());
         openLoan.setRecall(event.getDueDateChangedByRecall());
+        if(!event.getDueDateChangedByRecall()){
+          openLoan.setItemLost(false);
+        }
       }, () -> logOpenLoanNotFound(event, event.getLoanId()));
   }
 

--- a/src/main/java/org/folio/service/UserSummaryService.java
+++ b/src/main/java/org/folio/service/UserSummaryService.java
@@ -297,7 +297,7 @@ public class UserSummaryService {
       .ifPresentOrElse(openLoan -> {
         openLoan.setDueDate(event.getDueDate());
         openLoan.setRecall(event.getDueDateChangedByRecall());
-        if(Boolean.FALSE.equals(event.getDueDateChangedByRecall())){
+        if (Boolean.FALSE.equals(event.getDueDateChangedByRecall())){
           openLoan.setItemLost(false);
         }
       }, () -> logOpenLoanNotFound(event, event.getLoanId()));

--- a/src/test/java/org/folio/service/UserSummaryServiceTest.java
+++ b/src/test/java/org/folio/service/UserSummaryServiceTest.java
@@ -57,7 +57,7 @@ public class UserSummaryServiceTest extends TestBase {
   }
 
   @Test
-  public void shouldAddLoanDueDateChangedEventAndTurnItemLostToFalse(TestContext context) {
+  public void loanDueDateChangedEventShouldSetItemLostToFalse(TestContext context) {
     String userId = randomId();
     String loanId = randomId();
     Date dueDate = now().plusHours(1).toDate();

--- a/src/test/java/org/folio/service/UserSummaryServiceTest.java
+++ b/src/test/java/org/folio/service/UserSummaryServiceTest.java
@@ -1,26 +1,21 @@
 package org.folio.service;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.repository.UserSummaryRepository.USER_SUMMARY_TABLE_NAME;
 import static org.folio.rest.utils.EntityBuilder.buildFeeFineBalanceChangedEvent;
 import static org.folio.rest.utils.EntityBuilder.buildItemAgedToLostEvent;
 import static org.folio.rest.utils.EntityBuilder.buildItemCheckedOutEvent;
 import static org.folio.rest.utils.EntityBuilder.buildLoanDueDateChangedEvent;
-import static org.hamcrest.CoreMatchers.is;
 import static org.joda.time.DateTime.now;
 
 import java.math.BigDecimal;
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
-import org.awaitility.Awaitility;
 import org.folio.repository.UserSummaryRepository;
 import org.folio.rest.TestBase;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
 import org.folio.rest.jaxrs.model.ItemAgedToLostEvent;
 import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
 import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
-import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/folio/service/UserSummaryServiceTest.java
+++ b/src/test/java/org/folio/service/UserSummaryServiceTest.java
@@ -1,13 +1,26 @@
 package org.folio.service;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.repository.UserSummaryRepository.USER_SUMMARY_TABLE_NAME;
 import static org.folio.rest.utils.EntityBuilder.buildFeeFineBalanceChangedEvent;
+import static org.folio.rest.utils.EntityBuilder.buildItemAgedToLostEvent;
+import static org.folio.rest.utils.EntityBuilder.buildItemCheckedOutEvent;
+import static org.folio.rest.utils.EntityBuilder.buildLoanDueDateChangedEvent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.joda.time.DateTime.now;
 
 import java.math.BigDecimal;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.folio.repository.UserSummaryRepository;
 import org.folio.rest.TestBase;
 import org.folio.rest.jaxrs.model.FeeFineBalanceChangedEvent;
+import org.folio.rest.jaxrs.model.ItemAgedToLostEvent;
+import org.folio.rest.jaxrs.model.ItemCheckedOutEvent;
+import org.folio.rest.jaxrs.model.LoanDueDateChangedEvent;
+import org.folio.rest.jaxrs.model.OpenLoan;
 import org.folio.rest.jaxrs.model.UserSummary;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +59,33 @@ public class UserSummaryServiceTest extends TestBase {
     UserSummary updatedUserSummary = waitFor(userSummaryService.getByUserId(userId));
     context.assertTrue(updatedUserSummary.getOpenFeesFines().stream()
       .anyMatch(openFeeFine -> openFeeFine.getFeeFineId().equals(feeFineId)));
+  }
+
+  @Test
+  public void shouldAddLoanDueDateChangedEventAndTurnItemLostToFalse(TestContext context) {
+    String userId = randomId();
+    String loanId = randomId();
+    Date dueDate = now().plusHours(1).toDate();
+
+    waitFor(userSummaryRepository.save(createUserSummary(randomId(), userId)));
+    UserSummary userSummary = waitFor(userSummaryService.getByUserId(userId));
+
+    ItemCheckedOutEvent itemCheckedOutEvent = buildItemCheckedOutEvent(userId, loanId, dueDate);
+    userSummaryService.updateUserSummaryWithEvent(userSummary, itemCheckedOutEvent);
+
+    ItemAgedToLostEvent itemAgedToLostEvent = buildItemAgedToLostEvent(userId, loanId);
+    waitFor(userSummaryService.updateUserSummaryWithEvent(userSummary, itemAgedToLostEvent));
+
+    UserSummary updatedUserSummary = waitFor(userSummaryService.getByUserId(userId));
+    context.assertTrue(updatedUserSummary.getOpenLoans().stream()
+      .anyMatch(openLoan -> openLoan.getItemLost().equals(true)));
+
+    LoanDueDateChangedEvent loanDueDateChangedEvent = buildLoanDueDateChangedEvent(userId, loanId, now().plusHours(2).toDate(), false);
+    waitFor(userSummaryService.updateUserSummaryWithEvent(userSummary, loanDueDateChangedEvent));
+    updatedUserSummary = waitFor(userSummaryService.getByUserId(userId));
+
+    context.assertTrue(updatedUserSummary.getOpenLoans().stream()
+      .anyMatch(loan -> loan.getLoanId().equals(loanId) && loan.getItemLost().equals(false)));
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Fix issue with automated patron blocks not disappearing after renewal of Aged to lost item 
### Approach

- Updated UserSummary
- Added test

### Learning
https://issues.folio.org/browse/MODPATBLK-126
