### PR TITLE
MODPATBLK-137 RMB v34 upgrade - Morning Glory 2022 R2 module release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.2.4</raml-module-builder.version>
+    <raml-module-builder.version>34.0.0</raml-module-builder.version>
     <vertx.version>4.1.5</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.0</rest-assured.version>


### PR DESCRIPTION
In the scope of the task on module upgrade, proper actions were fulfilled following instructions to upgrade RAML

Upgraded version of RMB to 34.0.0

https://issues.folio.org/browse/MODPATBLK-137