### PR TITLE
MODPATBLK-144: mod-pubsub-client 2.6.1 fixing Remote Code Execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.3.0</version>
+      <version>2.6.1</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade mod-pubsub-client from 2.3.0 to 2.6.1.

Upgrading mod-pubsub-client indirectly upgrades spring-beans from 5.2.8.RELEASE to 5.3.20 fixing Remote Code Execution https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrading mod-pubsub-client indirectly upgrades scala-library from 2.13.1 to 2.13.8 fixing Remote Code Execution (RCE) https://nvd.nist.gov/vuln/detail/CVE-2022-36944