### PR TITLE
MODPATBLK-148: Sporadic test failures caused by async race condition

### DIFF
--- a/src/test/java/org/folio/rest/TestBase.java
+++ b/src/test/java/org/folio/rest/TestBase.java
@@ -8,12 +8,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Base64;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -33,6 +35,7 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.utils.EventClient;
 import org.folio.rest.utils.OkapiClient;
 import org.folio.rest.utils.PomUtils;
+import org.hamcrest.Matcher;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -228,6 +231,10 @@ public class TestBase {
       .until(future::isComplete);
 
     return future.result();
+  }
+
+  protected static <T> void awaitUntil(Callable<T> supplier, Matcher<? super T> matcher) {
+    Awaitility.await().atMost(5, SECONDS).until(supplier, matcher);
   }
 
   protected static String toJson(Object event) {

--- a/src/test/java/org/folio/rest/impl/SynchronizationAPITests.java
+++ b/src/test/java/org/folio/rest/impl/SynchronizationAPITests.java
@@ -17,9 +17,6 @@ import static org.folio.rest.utils.matcher.SynchronizationJobMatchers.synchroniz
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.joda.time.LocalDateTime.now;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Date;
 import java.util.List;
 
@@ -175,14 +172,12 @@ public class SynchronizationAPITests extends TestBase {
   @Test
   public void agedToLostEventShouldBeDeletedBeforeSynchronizationJobByUser() {
     eventClient.sendEvent(buildItemAgedToLostEvent(USER_ID, randomId()));
-    assertThat(waitFor(itemAgedToLostEventRepository.getByUserId(USER_ID)).size(), is(1));
+    awaitUntil(() -> waitFor(itemAgedToLostEventRepository.getByUserId(USER_ID)).size(), is(1));
     String syncJobId = createOpenSynchronizationJobByUser();
 
     runSynchronization();
 
-    Awaitility.await()
-      .atMost(5, SECONDS)
-      .until(() -> waitFor(itemAgedToLostEventRepository.getByUserId(USER_ID)).size(), is(0));
+    awaitUntil(() -> waitFor(itemAgedToLostEventRepository.getByUserId(USER_ID)).size(), is(0));
 
     checkSyncJob(syncJobId);
   }

--- a/src/test/java/org/folio/service/UserSummaryServiceTest.java
+++ b/src/test/java/org/folio/service/UserSummaryServiceTest.java
@@ -5,6 +5,7 @@ import static org.folio.rest.utils.EntityBuilder.buildFeeFineBalanceChangedEvent
 import static org.folio.rest.utils.EntityBuilder.buildItemAgedToLostEvent;
 import static org.folio.rest.utils.EntityBuilder.buildItemCheckedOutEvent;
 import static org.folio.rest.utils.EntityBuilder.buildLoanDueDateChangedEvent;
+import static org.hamcrest.Matchers.is;
 import static org.joda.time.DateTime.now;
 
 import java.math.BigDecimal;
@@ -51,9 +52,11 @@ public class UserSummaryServiceTest extends TestBase {
 
     userSummaryService.updateUserSummaryWithEvent(userSummary, feeFineBalanceChangedEvent);
 
-    UserSummary updatedUserSummary = waitFor(userSummaryService.getByUserId(userId));
-    context.assertTrue(updatedUserSummary.getOpenFeesFines().stream()
-      .anyMatch(openFeeFine -> openFeeFine.getFeeFineId().equals(feeFineId)));
+    awaitUntil(() -> {
+      UserSummary updatedUserSummary = waitFor(userSummaryService.getByUserId(userId));
+      return updatedUserSummary.getOpenFeesFines().stream()
+          .anyMatch(openFeeFine -> openFeeFine.getFeeFineId().equals(feeFineId));
+    }, is(true));
   }
 
   @Test

--- a/src/test/java/org/folio/service/UserSummaryServiceTest.java
+++ b/src/test/java/org/folio/service/UserSummaryServiceTest.java
@@ -5,8 +5,8 @@ import static org.folio.rest.utils.EntityBuilder.buildFeeFineBalanceChangedEvent
 import static org.folio.rest.utils.EntityBuilder.buildItemAgedToLostEvent;
 import static org.folio.rest.utils.EntityBuilder.buildItemCheckedOutEvent;
 import static org.folio.rest.utils.EntityBuilder.buildLoanDueDateChangedEvent;
-import static org.hamcrest.Matchers.is;
 import static org.joda.time.DateTime.now;
+import static org.awaitility.Awaitility.await;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -52,11 +52,10 @@ public class UserSummaryServiceTest extends TestBase {
 
     userSummaryService.updateUserSummaryWithEvent(userSummary, feeFineBalanceChangedEvent);
 
-    awaitUntil(() -> {
-      UserSummary updatedUserSummary = waitFor(userSummaryService.getByUserId(userId));
-      return updatedUserSummary.getOpenFeesFines().stream()
-          .anyMatch(openFeeFine -> openFeeFine.getFeeFineId().equals(feeFineId));
-    }, is(true));
+    await().until(() ->
+        waitFor(userSummaryService.getByUserId(userId))
+        .getOpenFeesFines().stream()
+        .anyMatch(openFeeFine -> openFeeFine.getFeeFineId().equals(feeFineId)));
   }
 
   @Test


### PR DESCRIPTION
Run this on GitHub Actions ubuntu-latest:

```
mvn test -Dtest=SynchronizationAPITests
```

50% of all runs have this failure:

```
[ERROR]   SynchronizationAPITests.agedToLostEventShouldBeDeletedBeforeSynchronizationJobByUser:178
Expected: is <1>
     but: was <0>
```

The API processes the aged-to-lost event asynchronously, it returns a 201 success without waiting for the event being stored to database: https://github.com/folio-org/mod-patron-blocks/blob/v1.7.0/src/main/java/org/folio/rest/impl/EventHandlersAPI.java#L88-L99

Therefore the test must wait until the event is in the database.

A similar issue:
```
[ERROR]   UserSummaryServiceTest.shouldAddEvent:55 Expected true
```