### PR TITLE
MODPATBLK-149: Upgrade pubsub, RMB, Vert.x for Nolana

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version>
-    <vertx.version>4.3.3</vertx.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version>
+    <vertx.version>4.3.4</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade mod-pubsub-client from Morning Glory version 2.6.1 to Nolana version 2.7.0.

The new mod-pubsub-client version no longer ships with org.scala-lang:scala-library and org.apache.kafka:kafka-clients that are not needed by mod-pubsub-client and by mod-patron-blocks. There were vulnerabilities in them: https://nvd.nist.gov/vuln/detail/CVE-2022-36944
https://nvd.nist.gov/vuln/detail/CVE-2022-34917

Upgrade Vert.x from 4.3.3 to 4.3.4.
Upgrade RMB from 35.0.0 to 35.0.1.

Upgrading RMB indirectly upgrades jackson-databind from 2.13.2.1 to 2.13.4 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2022-42004