### PR TITLE
MODPATBLK-152: spring+scala vulns (CVE-2022-22965, CVE-2022-36944) MG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,18 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.2.22.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>2.13.10</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
For 2022-R2 Morning Glory Hot Fix:

Upgrade spring-beans from 5.2.8.RELEASE to 5.2.22.RELEASE fixing Spring4Shell Remote Code Execution:
https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrade scala-library from 2.13.1 to 2.13.10 fixing Remote Code Execution (RCE):
https://nvd.nist.gov/vuln/detail/CVE-2022-36944

Before the fix:

```
$ mvn dependency:tree -Dincludes=org.scala-lang,org.springframework
[INFO] org.folio:mod-patron-blocks:jar:1.6.0
[INFO] \- org.folio:mod-pubsub-client:jar:2.3.0:compile
[INFO]    +- org.folio:folio-di-support:jar:1.2.0:compile
[INFO]    |  +- org.springframework:spring-core:jar:5.2.8.RELEASE:compile
[INFO]    |  |  \- org.springframework:spring-jcl:jar:5.2.8.RELEASE:compile
[INFO]    |  \- org.springframework:spring-context:jar:5.2.8.RELEASE:compile
[INFO]    |     +- org.springframework:spring-aop:jar:5.2.8.RELEASE:compile
[INFO]    |     +- org.springframework:spring-beans:jar:5.2.8.RELEASE:compile
[INFO]    |     \- org.springframework:spring-expression:jar:5.2.8.RELEASE:compile
[INFO]    \- org.scala-lang:scala-library:jar:2.13.1:compile
```

After the fix:

```
$ mvn dependency:tree -Dincludes=org.scala-lang,org.springframework
[INFO] org.folio:mod-patron-blocks:jar:1.6.1-SNAPSHOT
[INFO] \- org.folio:mod-pubsub-client:jar:2.3.0:compile
[INFO]    +- org.folio:folio-di-support:jar:1.2.0:compile
[INFO]    |  +- org.springframework:spring-core:jar:5.2.22.RELEASE:compile
[INFO]    |  |  \- org.springframework:spring-jcl:jar:5.2.22.RELEASE:compile
[INFO]    |  \- org.springframework:spring-context:jar:5.2.22.RELEASE:compile
[INFO]    |     +- org.springframework:spring-aop:jar:5.2.22.RELEASE:compile
[INFO]    |     +- org.springframework:spring-beans:jar:5.2.22.RELEASE:compile
[INFO]    |     \- org.springframework:spring-expression:jar:5.2.22.RELEASE:compile
[INFO]    \- org.scala-lang:scala-library:jar:2.13.10:compile
```