### PR TITLE
MODPATBLK-170: Check "error" in GET /_/tenant/<tenantid> in ApiIT

### DIFF
--- a/src/test/java/org/folio/rest/ApiIT.java
+++ b/src/test/java/org/folio/rest/ApiIT.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;


### PR DESCRIPTION
https://s3.amazonaws.com/foliodocs/api/raml/r/tenant.html#tenant__operation_id__get

Error is indicated in the "error" property only, not in the HTTP status code!