### PR TITLE
MODPATBLK-171: maven-model 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,6 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
https://issues.folio.org/browse/MODPATBLK-171

No longer downgrade maven-model from 3.8.6 to 3.3.9.

This upgrades plexus-utils from 3.0.22 to 3.3.1 fixing Directory Traversal and XML External Entity (XXE) Injection:
https://nvd.nist.gov/vuln/detail/CVE-2022-4244
https://nvd.nist.gov/vuln/detail/CVE-2022-4245