### PR TITLE
MODPATBLK-179 Generate ItemAgedToLostEvent during synchronization

### DIFF
--- a/src/test/java/org/folio/rest/impl/SynchronizationAPITests.java
+++ b/src/test/java/org/folio/rest/impl/SynchronizationAPITests.java
@@ -220,6 +220,23 @@ public class SynchronizationAPITests extends TestBase {
   }
 
   @Test
+  public void itemAgedToLostEventShouldBeCreatedAfterSynchronization() {
+    stubLoans(now().plusHours(1).toDate(), false, "Aged to lost");
+    stubAccountsWithEmptyResponse();
+    String syncJobId = createOpenSynchronizationJobByUser();
+    EventRepository<ItemAgedToLostEvent> itemAgedToLostEventRepository = new EventRepository<>(
+      postgresClient, ITEM_AGED_TO_LOST_EVENT_TABLE_NAME, ItemAgedToLostEvent.class);
+
+    runSynchronization();
+
+    Awaitility.await()
+      .atMost(5, SECONDS)
+      .until(() -> waitFor(itemAgedToLostEventRepository.getByUserId(USER_ID)).size(), is(1));
+
+    checkSyncJobUpdatedByLoanEvent(syncJobId);
+  }
+
+  @Test
   public void feeFineBalanceChangedEventShouldBeCreatedAfterSynchronization() {
     stubLoansWithEmptyResponse();
     stubAccounts();

--- a/src/test/java/org/folio/rest/impl/SynchronizationAPITests.java
+++ b/src/test/java/org/folio/rest/impl/SynchronizationAPITests.java
@@ -207,8 +207,6 @@ public class SynchronizationAPITests extends TestBase {
     stubLoans(now().plusHours(1).toDate(), true, "Checked out");
     stubAccountsWithEmptyResponse();
     String syncJobId = createOpenSynchronizationJobByUser();
-    EventRepository<LoanDueDateChangedEvent> loanDueDateChangedEventRepository = new EventRepository<>(
-      postgresClient, LOAN_DUE_DATE_CHANGED_EVENT_TABLE_NAME, LoanDueDateChangedEvent.class);
 
     runSynchronization();
 
@@ -224,8 +222,6 @@ public class SynchronizationAPITests extends TestBase {
     stubLoans(now().plusHours(1).toDate(), false, "Aged to lost");
     stubAccountsWithEmptyResponse();
     String syncJobId = createOpenSynchronizationJobByUser();
-    EventRepository<ItemAgedToLostEvent> itemAgedToLostEventRepository = new EventRepository<>(
-      postgresClient, ITEM_AGED_TO_LOST_EVENT_TABLE_NAME, ItemAgedToLostEvent.class);
 
     runSynchronization();
 


### PR DESCRIPTION
## Purpose
Generate "Item aged to lost" events during synchronization.
[MODPATBLK-179](https://folio-org.atlassian.net/browse/MODPATBLK-179)

## Approach
Add missing step to `LoanEventsGenerationService`

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [x] Database schema changes
- [x] Interface versions changes
- [x] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
- [x] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
