### PR TITLE
[MODFQMMGR-1162] Remove ambiguous FQM source/valueSourceApi field configs

### DIFF
--- a/ramls/userSummary.json
+++ b/ramls/userSummary.json
@@ -101,10 +101,6 @@
             "x-fqm-value-getter": "(SELECT array_agg(fee_fine_type.value->>'feeFineTypeId' ORDER BY fee_fine_type.value->>'feeFineTypeId') FROM jsonb_array_elements(:src__circulation__patron_blocks__user_summary.jsonb->'openFeesFines') AS fee_fine_type)",
             "x-fqm-filter-value-getter": "(SELECT array_agg(fee_fine_type.value->>'feeFineTypeId' ORDER BY fee_fine_type.value->>'feeFineTypeId') FROM jsonb_array_elements(:src__circulation__patron_blocks__user_summary.jsonb->'openFeesFines') AS fee_fine_type)",
             "x-fqm-data-type": "stringType",
-            "x-fqm-source": {
-              "columnName": "open_fees_fines[*]->fee_fine_type_id",
-              "entityTypeId": "f5443525-d2a9-5e59-8f4a-4ac526ec8528"
-            },
             "x-fqm-value-source-api": {
               "path": "feefines",
               "labelJsonPath": "$.feefines.*.feeFineType",


### PR DESCRIPTION
## Purpose
[MODFQMMGR-1162](https://folio-org.atlassian.net/browse/MODFQMMGR-1162): Remove ambiguous FQM source/valueSourceApi field configs

Does not need to be released.