### PR TITLE
MODPATBLK-232 Add missing dependencies

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -21,6 +21,10 @@
     {
       "id": "users",
       "version": "15.1 16.0"
+    },
+    {
+      "id": "feesfines",
+      "version": "19.1"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODPATBLK-232

## Approach
Add missing interface dependency `feesfines` `19.1`

Called endpoint | Interface (master branch) | Descriptor dependency | Covered?
-- | -- | -- | --
GET /users/{userId} | users 16.5 | users 15.1 16.0 | Yes
GET /loan-storage/loans | loan-storage 7.4 | loan-storage 7.0 | Yes
GET /accounts | feesfines 19.1 | feesfines 19.1 | Yes
POST /pubsub/event-types | pubsub-event-types 0.1 | pubsub-event-types 0.1 | Yes
POST /pubsub/event-types/declare/publisher | pubsub-publishers 0.1 | pubsub-publishers 0.1 | Yes
POST /pubsub/event-types/declare/subscriber | pubsub-subscribers 0.1 | pubsub-subscribers 0.1 | Yes


